### PR TITLE
Introduce v0.2.0 design docs: canonical FastAPI, automatic seam map, deterministic pipeline & verification

### DIFF
--- a/plans/v0-2-0/00-overview/README.md
+++ b/plans/v0-2-0/00-overview/README.md
@@ -1,0 +1,313 @@
+# MidiCoder v0.2.0 - Thiết kế tổng thể big update
+
+## 1. Mục tiêu của bản v0.2.0
+
+Bản v0.2.0 là một đợt nâng cấp kiến trúc lớn với các mục tiêu sau:
+
+1. Giảm LLM xuống mức tối thiểu, lý tưởng chỉ còn ở `contract gen`.
+2. Chuyển `code build` từ sinh metadata/pseudo-struct sang sinh **canonical FastAPI executable code**.
+3. Chuyển `code gen` thành pha **integration + adaptation + patch planning**, ưu tiên deterministic.
+4. Chuyển `code apply` thành **file operation executor thuần túy**, không còn quyết định nội dung nghiệp vụ.
+5. Thay `runtime test` từ startup smoke test sang **verification pipeline thật** gồm lint, typecheck, unit test, smoke test.
+6. Thay `runtime fix` từ LLM patching sang **deterministic remediation orchestration**, tạo remediation brief/version mới và chạy lại pipeline ở pha phù hợp.
+7. Loại bỏ khái niệm người dùng phải biết hoặc đặt seam. Hệ thống chỉ còn khái niệm **automatic seam map** được Midicoder tự động suy luận từ codebase.
+8. Mở rộng DSL/IR để đủ sức mô hình hóa SaaS lớn, modular monolith, và microservice multi-service.
+9. Đợt v0.2.0 chỉ tập trung **backend, microservice, big-app backend**; chưa đưa frontend support vào phạm vi chính thức.
+10. DSL mới phải hỗ trợ **full test generation** để dùng cho `runtime test`, với mục tiêu coverage tối thiểu **85%** ở generated test suite.
+
+---
+
+## 2. Nguyên tắc kiến trúc mới
+
+### 2.1 Contract-first nhưng không LLM-first
+
+- `brief rewrite` và `contract gen` vẫn có thể dùng LLM vì đây là pha chuyển ngôn ngữ tự nhiên thành DSL có cấu trúc.
+- Từ `contract check` trở đi, mọi pha cần ưu tiên deterministic compiler pipeline.
+
+### 2.2 Canonical backend IR ở mức code
+
+Thay vì dùng `pseudo_struct` làm intermediate chính, v0.2.0 định nghĩa một tầng mới:
+
+- **Canonical FastAPI Code**
+  - là Python code hợp lệ
+  - phản ánh logic nghiệp vụ đã được compile từ IR
+  - có anchors, ownership, contract refs, semantic markers
+  - chưa nhất thiết là production-grade code cuối cùng cho workdir thật
+
+Canonical FastAPI Code là "mã trung gian có thể chạy được" để các stack generator downstream có thể dịch hoặc merge một cách deterministic.
+
+### 2.3 Không còn “real seam” vs “virtual seam” như khái niệm sản phẩm
+
+Ở góc nhìn end-user:
+
+- người dùng **không biết** seam là gì
+- người dùng **không cần tạo** seam
+- Midicoder phải tự suy luận vị trí chèn/sửa code
+
+Do đó v0.2.0 thay thế:
+
+- `seams`
+- `virtual_seams`
+
+bằng một khái niệm duy nhất ở cấp sản phẩm:
+
+- **automatic seam map**
+
+Automatic seam map là output của lệnh `midicoder index`, được xây dựng tự động từ:
+
+- symbols
+- imports
+- file/module structure
+- entrypoints
+- framework conventions
+- ownership inference
+- code exemplars
+- AST boundaries
+- comment markers cũ (nếu tồn tại)
+
+Nếu repo có marker cũ `midicoder:begin/end`, chúng chỉ là **một nguồn tín hiệu** của automatic seam map, không còn là khái niệm public-facing.
+
+### 2.4 `code apply` phải luôn reindex bằng `midicoder index`
+
+Ngay sau khi apply patch thành công, Midicoder **phải tự chạy lại lệnh `midicoder index`** trên workdir hiện tại.
+
+Lý do:
+
+1. Context artifacts phải đồng bộ với codebase sau apply.
+2. Automatic seam map, symbol graph, file ownership, entrypoints có thể đã thay đổi.
+3. Pha kế tiếp (`code gen`, `runtime test`, `runtime fix`) phải nhìn thấy trạng thái repo mới nhất.
+4. Cơ chế “reindex changed files only” là optimization nội bộ, nhưng contract hệ thống ở cấp command phải được phát biểu là: **`code apply` luôn trigger `midicoder index`**.
+
+### 2.5 Verification-first remediation
+
+- `runtime test` không còn chỉ là boot app.
+- `runtime fix` không còn tự sinh patch bằng LLM.
+- Thay vào đó, hệ thống:
+  - chạy verification pipeline thật
+  - phân loại lỗi
+  - quyết định lỗi implementation hay contract/brief
+  - tạo remediation brief hoặc remediation task set
+  - tạo version mới
+  - chạy lại pipeline từ pha thích hợp
+
+---
+
+## 3. Luồng pipeline mới đề xuất
+
+### 3.1 Luồng chuẩn
+
+1. `midicoder brief rewrite`
+2. `midicoder contract gen`
+3. `midicoder contract repair`
+4. `midicoder index`
+5. `midicoder ir build`
+6. `midicoder contract check`
+7. `midicoder code build`
+8. `midicoder code gen`
+9. `midicoder code apply`
+10. `midicoder index` (auto-run bắt buộc ngay sau apply)
+11. `midicoder runtime test`
+12. `midicoder runtime fix`
+
+### 3.2 Nguyên tắc phân vai
+
+- `brief rewrite`: làm rõ product intent thành brief kỹ thuật hóa.
+- `contract gen`: sinh DSL contract chuẩn.
+- `contract repair`: sửa contract bằng rule-based diagnostics.
+- `index`: tạo automatic seam map + project graph + symbol graph.
+- `ir build`: compile contracts sang IR giàu ngữ nghĩa.
+- `code build`: compile IR sang canonical FastAPI executable code cho **backend**.
+- `code gen`: generate patch plan vào workdir/target backend stack từ canonical code + context.
+- `code apply`: execute patch plan và reindex.
+- `runtime test`: verify chất lượng code thật + generated tests + coverage.
+- `runtime fix`: tạo remediation cycle không cần LLM.
+
+---
+
+## 4. Automatic seam map thay thế seam/virtual seam
+
+### 4.1 Vấn đề của mô hình hiện tại
+
+Mô hình hiện tại tách:
+
+- seam thật: từ marker `midicoder:begin/end`
+- virtual seam: suy luận từ symbols, exemplars, entrypoints
+
+Nhược điểm:
+
+1. Lộ chi tiết implementation nội bộ ra mô hình mental của sản phẩm.
+2. Khiến code build/code gen bị phụ thuộc vào khái niệm người dùng không quan tâm.
+3. Làm planner phải branch logic `real seam` vs `virtual seam`.
+4. Tạo cảm giác hệ thống chỉ hoạt động tốt nếu repo đã “chuẩn bị sẵn anchor”.
+
+### 4.2 Mô hình mới
+
+Automatic seam map là một danh sách **insertion/update candidates** với confidence score, ví dụ:
+
+- file path
+- AST span
+- symbol owner
+- role (`controller`, `service`, `model`, `bootstrap`, `config`, `test`)
+- insertion strategy (`replace_symbol`, `replace_region`, `append_to_module`, `create_file`, `insert_import`, ...)
+- ownership class (`owned`, `shared`, `foreign`, `generated`)
+- confidence
+- evidence list
+
+### 4.3 Nguồn tín hiệu
+
+Automatic seam map được suy luận từ nhiều tầng:
+
+1. AST symbol extraction
+2. import graph
+3. routing conventions
+4. framework entrypoints
+5. project profile + stack detector
+6. file naming conventions
+7. exemplar snippets
+8. comment markers legacy
+9. git history / changed path history (optional về sau)
+10. previous Midicoder generation metadata
+
+### 4.4 Product contract mới
+
+Ở tài liệu và CLI help, Midicoder không còn dùng thuật ngữ seam như input contract của user.
+
+Nếu cần giữ backward compatibility cho artifact cũ:
+
+- `seams.json` và `virtual_seams.json` có thể vẫn tồn tại 1-2 version
+- nhưng được coi là legacy implementation detail
+- docs mới chỉ mô tả `automatic seam map`
+
+---
+
+## 5. Hướng mở rộng DSL và IR cho SaaS lớn / microservice
+
+### 5.1 Vấn đề hiện tại
+
+DSL hiện tại thiên về một service/backend tương đối đơn khối. Để hỗ trợ SaaS lớn hoặc microservice, cần các lớp mô hình mới.
+
+### 5.2 Cần bổ sung ở cấp DSL
+
+1. **System topology**
+   - bounded contexts
+   - services
+   - public/internal APIs
+   - async topics/queues
+   - external systems
+
+2. **Tenancy & billing**
+   - tenant model
+   - tenant isolation mode
+   - subscription plans
+   - quotas / entitlements
+   - billing events
+
+3. **Identity & access at scale**
+   - organizations / teams / workspaces
+   - role binding scope
+   - policy inheritance
+   - machine-to-machine credentials
+
+4. **Storage topology**
+   - per-service database
+   - read replicas
+   - caches
+   - object storage
+   - event store
+
+5. **Inter-service contracts**
+   - sync API contracts
+   - async event contracts
+   - workflow choreography/orchestration
+   - saga compensation contracts
+
+6. **Operational contracts**
+   - observability
+   - retry/dead-letter policies
+   - rate limit
+   - idempotency
+   - migration policy
+
+7. **Frontend and admin surface (optional future)**
+   - admin modules
+   - user portals
+   - BFF/API gateway contracts
+
+### 5.3 Cần bổ sung ở cấp IR
+
+IR v0.2.0 nên có thêm:
+
+- service graph
+- deployment boundary
+- ownership graph
+- integration contracts normalized
+- policy graph theo scope
+- workflow graph liên service
+- storage access graph
+- canonical refs cho tenancy/billing/quotas
+
+---
+
+## 6. Các tài liệu thiết kế command-level
+
+Bộ tài liệu được chia thành các subfolder theo thứ tự release patch trong nhánh `v0.2.0`:
+
+### 6.1 `01-contract-foundation/`
+
+1. `01-contract-foundation/brief-rewrite.md`
+2. `01-contract-foundation/contract-gen.md`
+3. `01-contract-foundation/contract-check.md`
+4. `01-contract-foundation/contract-repair.md`
+
+### 6.2 `02-index-context/`
+
+5. `02-index-context/index-command.md`
+
+### 6.3 `03-backend-codegen/`
+
+6. `03-backend-codegen/code-build.md`
+7. `03-backend-codegen/code-gen.md`
+8. `03-backend-codegen/code-apply.md`
+
+### 6.4 `04-runtime-quality/`
+
+9. `04-runtime-quality/runtime-test.md`
+10. `04-runtime-quality/runtime-fix.md`
+
+> Ghi chú: file hiện tại là overview tổng thể; roadmap này cố ý tập trung backend/microservice/backend-at-scale, không bao gồm frontend support trong patch set v0.2.0.
+
+---
+
+## 7. Quy ước tài liệu thiết kế v0.2.0
+
+Mỗi tài liệu command-level phải mô tả ở cấp super-detail:
+
+1. Product goal
+2. Non-goals
+3. Inputs
+4. Outputs
+5. Artifacts
+6. Data model
+7. Algorithm phases
+8. Deterministic vs optional model usage
+9. Failure modes
+10. Recovery rules
+11. Idempotency
+12. Observability / run artifacts
+13. Backward compatibility
+14. Migration strategy
+15. Test strategy
+16. Open questions
+
+---
+
+## 8. Quyết định sản phẩm chốt cho v0.2.0
+
+1. `code build` sinh canonical FastAPI executable code.
+2. `code gen` ưu tiên deterministic; LLM chỉ là fallback architecture-level, không phải đường mặc định.
+3. `code apply` luôn trigger `midicoder index` ngay sau apply thành công.
+4. `runtime test` là verification pipeline thật, không chỉ startup.
+5. `runtime fix` không dùng LLM; thay bằng remediation loop tạo version mới.
+6. `seams`/`virtual seams` bị hạ cấp thành implementation detail legacy; public model mới là automatic seam map.
+7. DSL/IR phải mở rộng để phục vụ SaaS lớn và multi-service.
+

--- a/plans/v0-2-0/01-contract-foundation/README.md
+++ b/plans/v0-2-0/01-contract-foundation/README.md
@@ -1,0 +1,10 @@
+# Patch 01 - Contract Foundation
+
+Patch đầu tiên của v0.2.0 tập trung vào:
+
+- brief rewrite
+- contract gen
+- contract check
+- contract repair
+
+Mục tiêu của patch này là chuẩn hóa product intent, mở rộng DSL cho backend/microservice, và tạo nền tảng đủ giàu cho các patch downstream.

--- a/plans/v0-2-0/01-contract-foundation/brief-rewrite.md
+++ b/plans/v0-2-0/01-contract-foundation/brief-rewrite.md
@@ -1,0 +1,256 @@
+# Thiết kế command `midicoder brief rewrite` - v0.2.0
+
+## 1. Mục tiêu tài liệu
+
+Tài liệu này có hai phần rõ ràng:
+
+1. **Phân tích chính xác code hiện tại** của `midicoder brief rewrite`.
+2. **Đề xuất thiết kế v0.2.0** dựa trên những gì code đang làm tốt/chưa tốt.
+
+Mục tiêu là tránh đoán mò và dùng lại đúng các quyết định/ưu nhược điểm hiện có làm nền cho redesign.
+
+---
+
+## 2. Hiện trạng code hiện có
+
+## 2.1 Entry point CLI hiện tại
+
+`midicoder brief rewrite` được triển khai tại `midicoder/commands/brief.py::rewrite()`.
+
+Luồng hiện tại:
+
+1. setup paths + current version
+2. đọc `.midicoder/versions/<version>/master-brief.md`
+3. load `llm.high`
+4. tạo run dir `brief_rewrite`
+5. gọi `midicoder.brief.rewriter.rewrite_master_brief(...)`
+6. ghi kết quả ra:
+   - `master-brief.updated.md`
+   - `master-brief.analysis.md`
+   - `master-brief.errors.txt` nếu có lỗi khi apply block
+7. ghi run outputs vào `.midicoder/runs/brief_rewrite/...`
+
+=> Điểm quan trọng: command hiện tại **không ghi đè** `master-brief.md`; nó tạo file `master-brief.updated.md` để user review rồi thay thế thủ công nếu muốn. Đây là một đặc điểm tốt cần giữ lại. Nó cũng luôn yêu cầu đã có `current_version` và `master-brief.md` trước khi chạy.
+
+## 2.2 Thuật toán thật sự trong `rewrite_master_brief()`
+
+Phần lõi nằm ở `midicoder/brief/rewriter.py::rewrite_master_brief()`.
+
+### Bước A - Build keyword map có cache
+
+Hàm này gọi `get_keyword_map_cached(...)` từ `midicoder.brief.analyzer`.
+
+Ý nghĩa:
+
+- brief hiện tại được hash bằng SHA-256
+- cache keyword map lưu tại `versions/<version>/cache/brief_keywords.json`
+- nếu hash brief không đổi thì tái sử dụng cache
+- nếu brief đổi hoặc cache miss thì gọi LLM để trích xuất:
+  - domain terms
+  - entities
+  - commands
+  - events
+  - apis
+  - integrations
+  - access_control
+  - persistence
+  - scenarios
+  - synonyms
+  - contract_files
+
+=> Đây là một optimization thật trong code hiện tại, không phải ý tưởng giả định.
+
+### Bước B - Tải context artifacts từ `.midicoder/context`
+
+`rewrite_master_brief()` load:
+
+- `symbols.json`
+- `virtual_seams.json`
+- nếu không có thì fallback sang `seams.json`
+- nếu vẫn không đủ thì dùng `exemplars.json`
+
+Luồng ưu tiên hiện tại là:
+
+1. virtual seams
+2. real seams
+3. symbols + exemplars
+
+Nói cách khác, brief rewrite hiện tại **phụ thuộc khá mạnh vào hệ thống index/context** để hiểu codebase, chứ không chỉ nhìn vào brief gốc.
+
+### Bước C - Multi-pass LLM rewrite
+
+Code hiện tại chạy 3 pass thật sự:
+
+#### Pass 1 - Summarize snippets
+
+- build prompt để tóm tắt các snippet code liên quan
+- LLM trả về JSON summaries
+
+#### Pass 2 - Aggregate module narratives
+
+- dùng context summaries từ pass 1
+- LLM gom thành các "module narratives"
+
+#### Pass 3 - Rewrite brief
+
+- build system prompt riêng cho rewrite
+- đưa `original_content` + `module_narratives`
+- LLM trả về các block search/replace
+- code parse block đó và apply lên brief gốc
+
+### Bước D - Apply search/replace blocks thay vì để model trả full file
+
+Đây là một điểm rất đáng chú ý trong implementation hiện tại:
+
+- model **không trả thẳng file brief hoàn chỉnh** như output chuẩn duy nhất
+- model trả về các block search/replace
+- code apply block lên `original_content`
+- nếu block nào không match thì ghi lỗi, nhưng vẫn có thể áp các block khác
+
+=> Đây là một thiết kế khá tốt về mặt an toàn vì giảm nguy cơ model rewrite toàn bộ file một cách mất kiểm soát.
+
+## 2.3 Output artifacts hiện tại
+
+Ngoài file updated brief, command đang lưu khá nhiều artifact hữu ích:
+
+- original brief
+- llm_config
+- prompt pass 1/2/3
+- raw response pass 1/2/3
+- context summaries
+- module narratives
+- final llm response
+- error.txt nếu fail
+
+=> Mức observability hiện tại tương đối tốt.
+
+---
+
+## 3. Ưu điểm của implementation hiện tại
+
+1. **Không ghi đè brief gốc** ngay lập tức.
+2. **Có cache keyword map**, tránh lặp LLM call không cần thiết.
+3. **Biết tận dụng context của repo** thông qua symbols/seams/exemplars.
+4. **Multi-pass architecture** hợp lý hơn single prompt rewrite.
+5. **Search/replace apply** an toàn hơn việc model trả full file rồi tin tuyệt đối.
+6. **Run logs chi tiết**, dễ debug.
+
+---
+
+## 4. Nhược điểm của implementation hiện tại
+
+1. Brief rewrite hiện vẫn bị buộc vào mô hình `virtual_seams`/`seams`, trong khi đây không phải mental model tự nhiên của end-user.
+2. Context retrieval hiện chưa dựa trên một artifact thống nhất kiểu project graph / automatic seam map.
+3. Output vẫn thiên về “improve master-brief.md” hơn là sinh ra một **canonical rewritten brief artifact** có schema ổn định.
+4. Cơ chế search/replace có thể fail từng block nếu brief đã drift so với text mà model nhìn thấy.
+5. Chưa có remediation mode tách bạch giữa:
+   - rewritten brief chuẩn
+   - remediation brief từ verification/runtime issues.
+
+---
+
+## 5. Thiết kế v0.2.0
+
+## 5.1 Mục tiêu mới
+
+`midicoder brief rewrite` ở v0.2.0 vẫn giữ tinh thần hiện tại, nhưng nâng thành pha:
+
+- chuẩn hóa brief đầu vào
+- tạo canonical rewritten brief
+- hỗ trợ remediation brief
+- gắn trace rõ giữa source brief và rewritten brief
+
+## 5.2 Những gì **giữ lại** từ code hiện tại
+
+1. Không ghi đè `master-brief.md` trực tiếp.
+2. Giữ keyword cache theo hash brief.
+3. Giữ multi-pass structure.
+4. Giữ prompt/response/run artifacts chi tiết.
+5. Giữ cơ chế apply patch-like changes thay vì blind full overwrite, nếu output mode là text patch.
+
+## 5.3 Những gì cần thay đổi
+
+### A. Đổi nền retrieval từ seam/virtual seam sang project context graph
+
+Thay vì:
+
+- `virtual_seams.json`
+- `seams.json`
+- exemplars fallback
+
+v0.2.0 dùng:
+
+- `automatic_seams.json`
+- `symbols.json`
+- `ownership.json`
+- `module_graph.json`
+- `entrypoints.json`
+- `exemplars.json`
+
+### B. Bổ sung rewritten brief schema
+
+Ngoài Markdown, command phải sinh JSON chuẩn hóa, ví dụ:
+
+- functional requirements
+- non-functional requirements
+- domain glossary
+- actors
+- entities
+- workflows
+- integrations
+- constraints
+- open questions
+
+### C. Tách remediation mode
+
+Khi downstream phát hiện lỗi contract/runtime, command phải có mode sinh `remediation brief` mới thay vì sửa đè rewritten brief cũ.
+
+### D. Tăng tính ổn định của apply model
+
+Tiếp tục ưu tiên patch-style application, nhưng nên hỗ trợ thêm structured edits ở mức section thay vì chỉ search/replace text thuần.
+
+---
+
+## 6. Thuật toán v0.2.0 đề xuất
+
+### Phase 1 - Load canonical inputs
+
+- source brief
+- previous rewritten brief nếu có
+- remediation signals nếu có
+- project context graph
+
+### Phase 2 - Keyword and concept extraction
+
+Giữ cache-based extraction như hiện tại.
+
+### Phase 3 - Context summarization
+
+Giữ multi-pass tư duy hiện tại nhưng retrieval source mới là project context graph.
+
+### Phase 4 - Rewrite planning
+
+Model sinh ra một structured rewrite plan:
+
+- section ops
+- additions
+- replacements
+- open questions
+
+### Phase 5 - Materialize outputs
+
+- `master-brief.updated.md`
+- rewritten brief JSON
+- analysis artifacts
+- remediation brief nếu applicable
+
+---
+
+## 7. Kết luận thiết kế
+
+Đây là command **được phép dùng LLM** ở v0.2.0. Tuy nhiên redesign phải bám sát 3 đặc tính tốt đã có trong code hiện tại:
+
+1. multi-pass context-aware rewrite
+2. keyword cache
+3. không ghi đè brief gốc trực tiếp
+

--- a/plans/v0-2-0/01-contract-foundation/contract-check.md
+++ b/plans/v0-2-0/01-contract-foundation/contract-check.md
@@ -1,0 +1,140 @@
+# Thiết kế command `midicoder contract check` - v0.2.0
+
+## 1. Mục tiêu tài liệu
+
+Tài liệu này bổ sung phần đã thiếu ở bản trước: phân tích chính xác `midicoder contract check` hiện đang làm gì trong code, rồi mới đề xuất redesign.
+
+---
+
+## 2. Hiện trạng code hiện có
+
+Entry point: `midicoder/commands/contract.py::check()`.
+
+Luồng hiện tại:
+
+1. setup version/path
+2. xác định `contracts_root`
+3. nếu có `master-brief.md` thì **thử** gọi lại `get_contract_files_from_master_brief(...)`
+   - mục đích: lấy danh sách `expected_files`
+4. nếu không analyze được brief thì fallback sang “check all existing yaml files”
+5. lọc `expected_files` chỉ giữ file tồn tại
+6. gọi `check_contract(contracts_root)`
+7. ghi run outputs
+8. nếu có issues thì in tối đa 5 issue và exit 1
+
+## 2.1 Điểm quan trọng dễ hiểu sai
+
+Mặc dù command cố gắng xác định `expected_files` từ brief, nhưng phần validation thực sự lại gọi:
+
+- `check_contract(contracts_root)`
+
+Hàm này validate toàn bộ contract tree từ `contracts_root`, không chỉ danh sách `expected_files` đã tính ở trên.
+
+=> Nói cách khác:
+
+- `expected_files` hiện chủ yếu để báo cáo `checked_files`
+- còn validation thật sự là ở scope toàn bộ contracts root
+
+Đây là chi tiết rất quan trọng để tránh mô tả sai command.
+
+## 2.2 `check_contract()` hiện đang làm gì
+
+Trong `midicoder/contract/contract_validator.py`, `check_contract(detail_path)`:
+
+1. validate một loạt file core và optional theo layout contract hiện tại
+2. load từng file bằng loader tương ứng
+3. chạy nhiều validator cross-file/cross-ref
+4. accumulate `ContractIssue`
+
+Danh sách file hiện được hardcode theo DSL hiện hành, ví dụ:
+
+- meta/info.yaml
+- glossary.yaml
+- domain/entities.yaml
+- domain/value_objects.yaml
+- domain/enums.yaml
+- domain/errors.yaml
+- domain/events.yaml
+- app/commands.yaml
+- app/queries.yaml
+- api/http.yaml
+- workflows/workflows.yaml
+- scenarios/scenarios.yaml
+- policy/rbac.yaml
+- api/graphql.yaml
+- persistence/model.yaml
+- integrations/integrations.yaml
+- meta/profiles.yaml
+- meta/secrets.yaml
+- policy/security.yaml
+- policy/reliability.yaml
+- ops/observability.yaml
+- testing/tests.yaml
+
+=> `contract check` hiện là validator **layout-aware và DSL-aware** khá sâu, không chỉ là lint YAML đơn thuần.
+
+---
+
+## 3. Ưu điểm của implementation hiện tại
+
+1. Có validator tập trung `check_contract()` khá rõ ràng.
+2. Check được nhiều lớp cross-ref, không chỉ schema.
+3. CLI output gọn, có run artifacts.
+4. Có fallback nếu brief analysis fail.
+
+---
+
+## 4. Nhược điểm của implementation hiện tại
+
+1. `contract check` vẫn thử gọi LLM-based brief analysis để lấy `expected_files`, dù phần validation thật không cần phụ thuộc hoàn toàn vào LLM.
+2. Danh sách DSL file còn gắn với schema hiện hành, chưa đủ cho big update SaaS/multi-service.
+3. `checked_files` reporting hiện có thể gây hiểu nhầm vì khác với validation scope thực tế.
+4. Chưa phân nhóm diagnostics rõ thành structural/semantic/architecture/brief-drift.
+
+---
+
+## 5. Thiết kế v0.2.0
+
+## 5.1 Mục tiêu mới
+
+`contract check` phải là command **deterministic hoàn toàn**.
+
+Nó không nên cần LLM để xác định phạm vi check mặc định.
+
+## 5.2 Scope model mới
+
+Command nên hỗ trợ các mode:
+
+- `full`: validate toàn bộ contracts root
+- `changed-only`: validate impacted files + dependents
+- `scope <name>`: validate một DSL scope cụ thể
+
+### Rule mặc định
+
+- default = `full`
+- không gọi brief analyzer trong đường mặc định
+
+## 5.3 Diagnostics model mới
+
+Mỗi issue cần có class:
+
+- structural
+- semantic_linkage
+- architecture
+- brief_drift
+- migration_warning
+
+## 5.4 Tích hợp với repair pipeline
+
+Output của `contract check` phải là input chuẩn cho:
+
+- `contract feedback`
+- `contract repair`
+- `runtime fix` classifier khi xác định contract-level defects
+
+---
+
+## 6. Kết luận thiết kế
+
+`contract check` hiện tại không phải command “đơn giản check các file từ brief”. Nó là validator tree-wide khá sâu. Thiết kế v0.2.0 phải giữ ưu điểm đó, nhưng loại bỏ dependency không cần thiết vào LLM trong đường mặc định và làm rõ semantics full-check của command.
+

--- a/plans/v0-2-0/01-contract-foundation/contract-gen.md
+++ b/plans/v0-2-0/01-contract-foundation/contract-gen.md
@@ -1,0 +1,255 @@
+# Thiết kế command `midicoder contract gen` - v0.2.0
+
+## 1. Mục tiêu tài liệu
+
+Tài liệu này mô tả:
+
+1. luồng `contract gen` hiện đang chạy trong codebase
+2. các ưu/nhược điểm thật sự của implementation hiện tại
+3. thiết kế v0.2.0 dựa trên hiện trạng đó, không đoán mò
+
+---
+
+## 2. Hiện trạng code hiện có
+
+## 2.1 Giới hạn phạm vi của đợt update này
+
+Pha `contract gen` của v0.2.0 chỉ tập trung vào **backend systems**:
+
+- modular monolith backend
+- microservice backend
+- big app backend
+- platform/service APIs
+
+Frontend support, UI contract generation, component/page DSL và frontend test synthesis **không nằm trong phạm vi patch set này**.
+
+## 2.1 Entry point CLI
+
+`midicoder contract gen` nằm tại `midicoder/commands/contract.py::gen()`.
+
+Luồng hiện tại:
+
+1. setup version/path
+2. đọc `master-brief.md`
+3. load config + `llm.high`
+4. build `system_prompt` với stack target + master brief
+5. gọi `get_contract_files_from_master_brief(...)`
+6. lấy ra `required_files`
+7. gọi `_generate_contract_files(...)` để generate **mỗi file một pass**
+
+=> `contract gen` hiện có hai pha LLM rõ ràng:
+
+- pha 1: xác định file contracts cần sinh
+- pha 2: sinh nội dung từng file contract
+
+## 2.2 Pha xác định contract files
+
+Hàm `get_contract_files_from_master_brief(...)` ở `midicoder/brief/analyzer.py`:
+
+- dùng cache `brief_keywords.json`
+- nếu cache miss/stale thì gọi LLM để trả JSON gồm keywords + `contract_files`
+- ép luôn `meta/info.yaml` và `glossary.yaml` phải có trong output
+
+Đây là behavior thật của code hiện tại.
+
+### Ưu điểm
+
+1. Có cache theo hash brief.
+2. Có contract file planning trước khi generate.
+3. Ép include `meta/info.yaml` + `glossary.yaml`, tránh output tối thiểu quá mức.
+
+### Nhược điểm
+
+1. Quyết định file list vẫn phụ thuộc mạnh vào prompt/LLM.
+2. Danh sách file hiện gắn với DSL hiện hữu, chưa đủ cho SaaS lớn/multi-service.
+3. Các command khác (`brief analyze`, `contract check`, `contract repair run`) cũng gọi lại logic này, có thể tạo coupling lớn giữa brief-analysis và contract lifecycle.
+
+## 2.3 Pha generate nội dung contract files
+
+`_generate_contract_files(...)` hiện làm như sau:
+
+1. tạo `run_dir`
+2. chia `required_files` thành `batches = [[file] for file in required_files]`
+   - nghĩa là **mỗi file là một pass riêng**
+3. cho từng pass:
+   - build context bằng `build_context_for_contract_gen(...)`
+   - save trace/prompt
+   - call LLM với `system_prompt` + `context_block` + `prompt`
+   - strip YAML code fences
+   - parse documents bằng `parse_contract_documents(...)`
+   - validate parsed_files
+   - ghi file ra `versions/<version>/contracts/...`
+
+=> Đây là one-file-per-pass architecture thật sự, không phải batch theo nhóm file.
+
+## 2.4 Observability hiện tại
+
+Implementation hiện tại khá mạnh ở mặt trace:
+
+- trace per pass
+- prompt saved
+- raw response saved
+- processed response saved
+- error artifacts
+- generation summary
+- resume support
+
+Ngoài ra còn có `contract gen resume` để đọc run gần nhất, xác định file nào đã thành công, file nào còn fail và resume phần còn lại.
+
+## 2.5 Ràng buộc hiện tại của system prompt
+
+System prompt được build từ:
+
+- version
+- stack target
+- master brief
+
+Prompt context lại đến từ `build_context_for_contract_gen(...)`. Nghĩa là contract gen hiện tại không chỉ dùng brief, mà còn dùng context/index artifacts và schema tree của repo.
+
+---
+
+## 3. Ưu điểm của implementation hiện tại
+
+1. **Có contract planning stage riêng**.
+2. **Có cache keyword map**, giảm duplicated analysis calls.
+3. **One-file-per-pass** giúp schema slicing rõ và dễ debug.
+4. **Resume được**, rất hữu ích khi một số pass fail giữa chừng.
+5. **Observability tốt** với trace/prompt/response đầy đủ.
+
+---
+
+## 4. Nhược điểm của implementation hiện tại
+
+1. Cả file planning và file generation đều phụ thuộc LLM.
+2. Danh sách DSL file hiện chưa đủ cho SaaS lớn hoặc multi-service.
+3. Generation granularity là per file, nhưng chưa có phase planning “semantic batches” ở cấp bounded context/service.
+4. Chưa có deterministic post-generation canonicalizer đủ mạnh ngoài parse/validate hiện có.
+5. Chưa tách rõ core contracts, topology contracts, tenancy/billing contracts, reliability/ops contracts.
+
+---
+
+## 5. Thiết kế v0.2.0
+
+## 5.1 Mục tiêu mới
+
+`contract gen` vẫn là một trong rất ít command còn dùng LLM mặc định. Nhưng v0.2.0 cần nâng nó thành:
+
+- contract compiler planner cho hệ lớn
+- DSL generator có topology awareness
+- source of truth đủ giàu cho `ir build` và `code build`
+
+## 5.2 Những gì cần giữ từ hiện trạng
+
+1. keyword cache
+2. one-file-per-pass hoặc one-batch-per-scope generation
+3. run traces rất chi tiết
+4. resume support
+
+## 5.3 Những gì cần thay đổi
+
+### A. Mở rộng DSL file planning
+
+Danh sách file mục tiêu phải vượt DSL hiện tại và bổ sung ít nhất:
+
+- topology/services.yaml
+- topology/messaging.yaml
+- tenancy/tenancy.yaml
+- billing/billing.yaml
+- ops/observability.yaml mở rộng
+- service-local integration contracts nếu multi-service
+
+### B. Thay per-file planning bằng scoped planning
+
+Thay vì chỉ hỏi “cần file nào?”, v0.2.0 nên plan theo scopes:
+
+- core domain
+- application/API
+- policy/security
+- workflow/process
+- persistence/integration
+- topology/tenancy/billing/ops
+
+### C. Strengthen deterministic validation
+
+Sau generate, không chỉ parse YAML mà còn validate:
+
+- cross-file refs
+- service ownership
+- tenancy scope consistency
+- async messaging topology
+- reliability policy completeness
+
+---
+
+## 6. Thuật toán v0.2.0 đề xuất
+
+### Phase 1 - Brief-driven contract scope planning
+
+Giữ keyword cache + file planning, nhưng nâng output thành:
+
+- required files
+- required scopes
+- service topology hints
+- domain boundaries
+
+### Phase 2 - Scoped generation
+
+Có thể vẫn per-file ở bước materialize, nhưng planning phải per-scope.
+
+### Phase 3 - Deterministic validation and canonicalization
+
+Phải có validate mạnh hơn code hiện tại trước khi cho phép `ir build`.
+
+### Phase 4 - Resume / retry
+
+Giữ tinh thần `contract gen resume` hiện tại.
+
+---
+
+## 7. Kết luận thiết kế
+
+`contract gen` là command nên tiếp tục được phép dùng LLM trong v0.2.0. Tuy nhiên redesign phải dựa trên 4 điểm thật đang có trong code:
+
+1. file planning qua brief analyzer + cache
+2. one-file-per-pass generation
+3. trace rất chi tiết
+4. resume support
+
+
+
+## 8. Yêu cầu mới: DSL phải hỗ trợ full test generation
+
+Đây là yêu cầu chốt mới của v0.2.0:
+
+1. DSL phải đủ giàu để sinh được **full tests** cho backend.
+2. Test contracts không chỉ mô tả scenario mức cao, mà phải support:
+   - unit tests
+   - integration tests
+   - API tests
+   - fixture/test data contracts
+   - coverage expectations
+3. `testing/tests.yaml` không còn là optional artifact yếu; nó phải trở thành source quan trọng cho `runtime test`.
+4. Mỗi bounded context/service phải khai báo được tối thiểu:
+   - critical paths
+   - invariants
+   - error cases
+   - auth/policy cases
+   - idempotency/retry cases nếu có
+5. Bộ generated test suite phải hướng tới **coverage >= 85%** trên backend business/application layers.
+
+### 8.1 Hệ quả lên DSL
+
+Cần bổ sung vào DSL ít nhất các khái niệm:
+
+- test suites theo layer
+- fixtures / seed data contracts
+- mock/stub integration policies
+- expected coverage targets
+- critical user journeys / service flows
+- contract-derived assertions
+
+### 8.2 Hệ quả lên downstream phases
+
+- `ir build` phải compile test intents vào IR
+- `code build` phải sinh canonical test skeletons hoặc canonical test plans
+- `runtime test` phải dùng generated tests như một phần mặc định của verification pipeline

--- a/plans/v0-2-0/01-contract-foundation/contract-repair.md
+++ b/plans/v0-2-0/01-contract-foundation/contract-repair.md
@@ -1,0 +1,198 @@
+# Thiết kế command `midicoder contract repair` - v0.2.0
+
+## 1. Phạm vi tài liệu
+
+Tài liệu này mô tả chính xác luồng hiện có của:
+
+- `midicoder contract repair prepare`
+- `midicoder contract repair run`
+
+trọng tâm là `repair run`, vì đây là nơi xử lý repair thật sự trong code hiện tại.
+
+---
+
+## 2. Hiện trạng code hiện có
+
+## 2.1 `contract repair prepare`
+
+Entry point: `midicoder/commands/contract.py::repair_prepare()`.
+
+Luồng hiện tại:
+
+1. setup version/path
+2. yêu cầu tồn tại `contract-feedbacks.yml`
+3. gọi `validate_feedback(...)`
+4. ghi run outputs `contract_repair_prepare`
+5. in report bằng `report_repair_status(...)`
+
+### `validate_feedback(...)` thực sự làm gì
+
+Trong `midicoder/contract/feedback_processor.py`:
+
+- parse YAML feedback file bằng `ruamel`
+- validate schema bằng `FeedbackFile.model_validate(...)`
+- kiểm tra `meta.version` có khớp current version không
+- normalize từng item.file sang contracts path hợp lệ
+- kiểm tra file contract tương ứng có tồn tại không
+
+=> `prepare` hiện là một bước **schema + path validation** cho feedback file, chưa repair gì cả.
+
+## 2.2 `contract repair run`
+
+Entry point: `midicoder/commands/contract.py::repair_run()`.
+
+Luồng hiện tại:
+
+1. validate feedback file
+2. lấy các `pending` hoặc `in_progress` items
+3. load `llm.high`, schema tree, master brief
+4. lại gọi `get_contract_files_from_master_brief(...)` để lấy available contract files
+5. group feedback items theo file bằng `group_feedback_by_file(...)`
+6. sắp xếp thứ tự file repair bằng `determine_file_repair_order(...)`
+7. xử lý **theo file**, không theo từng feedback item riêng lẻ
+8. mỗi file được xử lý bởi `process_file_feedback_items(...)`
+9. collect repair results và ghi summary
+
+=> Đây là một **file-level repair pipeline**, không phải single-item patch loop.
+
+## 2.3 `determine_file_repair_order()` đang làm gì
+
+Code hiện tại dùng pattern-based ordering:
+
+- foundation-like files: error/entity/event/glossary/info/meta
+- dependent-like files: command/query/http/api/rule/workflow/policy
+
+rồi trả thứ tự:
+
+1. foundation
+2. other
+3. dependent
+
+=> Đây là heuristic phụ thuộc tên file, không phải dependency graph chuẩn.
+
+## 2.4 `process_file_feedback_items()` hiện đang làm gì
+
+Đây là lõi thực sự của contract repair run.
+
+Cho mỗi file:
+
+1. đọc contract file hiện tại
+2. validate file riêng lẻ bằng `validate_single_contract_file(...)`
+3. extract existing IDs trong file
+4. extract available reference IDs từ dependency files
+5. build context cho contract repair bằng `build_context_for_contract_repair(...)`
+6. build comprehensive schema cho file type
+7. nếu có `available_contract_files`, bổ sung cross refs
+8. build prompt repair chi tiết
+9. save debug files
+10. gọi LLM với `CONTRACT_REPAIR_SYSTEM_PROMPT`
+11. parse repair plan
+12. apply patches ngay bằng `apply_contract_patches(...)`
+13. chạy một số safety fix hardcoded cho vài file đặc biệt
+14. revalidate file sau patch
+15. update feedback statuses
+16. trả result dict
+
+=> Có nghĩa là `contract repair run` hiện tại **không chỉ generate đề xuất**, mà còn **apply patches ngay lập tức** vào contracts.
+
+---
+
+## 3. Ưu điểm của implementation hiện tại
+
+1. **File-level repair** hợp lý hơn single-item repair vì giữ context toàn file.
+2. **Có feedback file formalized**, tạo quy trình sửa có trạng thái.
+3. **Có validation trước và sau patch**.
+4. **Có update trạng thái feedback items**.
+5. **Có debug artifacts per file**, giúp audit.
+
+---
+
+## 4. Nhược điểm của implementation hiện tại
+
+1. `repair run` vẫn phụ thuộc LLM làm trung tâm.
+2. Thứ tự dependency hiện mới là heuristic theo pattern, chưa phải graph-based.
+3. Có safety fix cục bộ hardcoded cho vài file, cho thấy pipeline chưa đủ tổng quát.
+4. Repair apply ngay vào contracts file, nên nếu prompt sai vẫn có nguy cơ patch không tối ưu.
+5. Chưa tách rõ deterministic repair path với scoped regenerate path.
+
+---
+
+## 5. Thiết kế v0.2.0
+
+## 5.1 Mục tiêu mới
+
+`contract repair` v0.2.0 nên trở thành command deterministic-first, gồm 2 lớp:
+
+- `prepare`: validation + repair planning
+- `run`: deterministic repair executor, chỉ fallback sang scoped regenerate khi cần
+
+## 5.2 Những gì cần giữ
+
+1. feedback file contract
+2. file-level grouping
+3. validation trước/sau sửa
+4. feedback status updates
+5. debug artifacts theo file
+
+## 5.3 Những gì cần thay đổi
+
+### A. Tách deterministic repair và regenerate
+
+- structural/simple semantic issues: deterministic patch
+- ambiguous semantic/architecture issues: scoped regenerate
+
+### B. Thay heuristic order bằng dependency graph
+
+Dựa trên:
+
+- reference graph giữa contracts
+- workflow bindings
+- route-command-query bindings
+- policy/resource references
+
+### C. Không để LLM apply trực tiếp là đường mặc định
+
+Nếu vẫn có LLM fallback trong giai đoạn chuyển tiếp, nó chỉ nên tạo candidate repair plan; deterministic layer phải validate và normalize trước khi apply.
+
+---
+
+## 6. Thuật toán v0.2.0 đề xuất
+
+### Phase 1 - Validate feedback
+
+Giữ logic chuẩn hóa từ `validate_feedback()`.
+
+### Phase 2 - Group + order by real dependency graph
+
+Thay `determine_file_repair_order()` heuristic bằng graph.
+
+### Phase 3 - Deterministic local repair
+
+Ưu tiên sửa:
+
+- canonical refs
+- missing required nodes/fields có thể infer chắc chắn
+- version mismatch / path mismatch
+- ownership/policy/resource normalization
+
+### Phase 4 - Scoped regenerate
+
+Nếu deterministic repair không đủ, rerun scoped `contract gen` cho file/scope liên quan.
+
+### Phase 5 - Revalidate + update feedback
+
+Giữ behavior hiện tại nhưng mở rộng diagnostics.
+
+---
+
+## 7. Kết luận thiết kế
+
+Redesign `contract repair run` phải bắt đầu từ việc thừa nhận đúng hiện trạng code:
+
+1. đây là file-level repair pipeline
+2. có feedback-state machine thật
+3. đang gọi LLM trực tiếp để tạo và apply repair plan
+4. có heuristic dependency ordering
+
+và v0.2.0 phải đẩy command này sang deterministic-first thay vì prompt-first.
+

--- a/plans/v0-2-0/02-index-context/README.md
+++ b/plans/v0-2-0/02-index-context/README.md
@@ -1,0 +1,3 @@
+# Patch 02 - Index Context
+
+Patch thứ hai của v0.2.0 tập trung vào `midicoder index` và việc thay public model `seams/virtual seams` bằng `automatic seam map` cùng project context graph thống nhất.

--- a/plans/v0-2-0/02-index-context/index-command.md
+++ b/plans/v0-2-0/02-index-context/index-command.md
@@ -1,0 +1,222 @@
+# Thiết kế command `midicoder index` - v0.2.0
+
+## 1. Mục tiêu tài liệu
+
+Tài liệu này phân tích đúng command `midicoder index` đang hoạt động như thế nào trong code hiện tại, sau đó mới mô tả redesign v0.2.0.
+
+---
+
+## 2. Hiện trạng code hiện có
+
+## 2.1 Entry points hiện tại
+
+`midicoder/commands/index.py` có 2 hàm public:
+
+- `run(root)`
+- `reindex(root, changed_paths=None)`
+
+Cả hai đều:
+
+1. resolve `working_dir` từ config
+2. đảm bảo `.midicoder` base layout
+3. tạo `run_dir`
+4. gọi `build_context(...)`
+
+Khác nhau ở chỗ:
+
+- `run()` gọi `build_context(..., refresh=False)`
+- `reindex()` gọi `build_context(..., refresh=True, reindex_only_changed=True, changed_paths=...)`
+
+=> Nghĩa là product hiện tại đã có split rõ giữa full index và incremental reindex.
+
+## 2.2 `build_context()` hiện thật sự làm gì
+
+Hàm lõi nằm ở `midicoder/context/indexer.py::build_context()`.
+
+Các pha chính hiện tại:
+
+### Phase A - Scan repository
+
+- load `.gitignore`
+- tạo `ProjectScanner`
+- scan toàn bộ hoặc scan selected files
+- maintain `FileCache`
+
+### Phase B - Full index hoặc incremental reindex
+
+#### Nếu `reindex_only_changed=True`
+
+- bắt buộc phải có existing context
+- ưu tiên `changed_paths` do caller truyền vào
+- nếu không có manual paths thì dùng git delta dựa trên `manifest.repo_hash`
+- merge lại với context cũ
+
+#### Nếu full index
+
+- scan toàn bộ
+- diff với previous files để biết changed/deleted
+
+### Phase C - Detect stack và profile
+
+- đọc stack từ config nếu có
+- detect stack từ scanner
+- extract project profile
+
+### Phase D - Extract project artifacts
+
+Hiện tại indexer extract:
+
+- symbols
+- entrypoints
+- seams
+- exemplars
+
+### Phase E - Merge artifacts trong refresh/reindex
+
+Khi refresh/reindex, code merge lại:
+
+- symbols
+- entrypoints
+- seams
+- exemplars
+
+với context cũ.
+
+### Phase F - Build manifest
+
+- nếu incremental: `build_incremental_manifest(...)`
+- nếu full: `build_index_manifest(...)`
+
+### Phase G - Write artifacts
+
+`write_context_artifacts(...)` ghi:
+
+- manifest.json
+- profile.json
+- symbols.json
+- entrypoints.json
+- seams.json
+- exemplars.json
+
+Sau đó nó gọi `write_virtual_seams(...)` để sinh `virtual_seams.json`.
+
+=> Điểm rất quan trọng: **virtual seams hiện được build sau khi đã có seams, symbols, entrypoints, exemplars**. Nó không phải artifact độc lập ngay từ đầu.
+
+---
+
+## 3. Seam và virtual seam hiện đang nghĩa là gì trong code
+
+## 3.1 Real seams
+
+`midicoder/context/extractors/seams.py` chỉ extract marker-based seams từ text:
+
+- `midicoder:begin <group_id>`
+- `midicoder:end <group_id>`
+
+Nó pair begin/end markers và tạo seam entries với:
+
+- kind begin/end
+- file
+- line
+- detail
+- group_id
+- paired
+
+=> Tức là **seam thật trong code hiện tại đúng nghĩa là marker-based anchors**.
+
+## 3.2 Virtual seams
+
+`midicoder/context/virtual_seams/pipeline.py` load và hợp nhất nhiều nguồn:
+
+- real seams
+- exemplar-derived virtual seams
+- symbol-derived virtual seams
+- entrypoint-derived virtual seams
+
+Sau đó:
+
+1. dedupe theo `(file, group_id)`
+2. dedupe tiếp theo `(file, line)` với priority rules
+3. merge real seams và virtual seams, real override by `group_id`
+
+=> Nói cách khác, virtual seam hiện tại là **candidate seam suy luận từ code intelligence**, còn real seam là marker do con người/công cụ đã cắm vào file.
+
+---
+
+## 4. Ưu điểm của implementation hiện tại
+
+1. Có hỗ trợ **incremental reindex** thật.
+2. Đã có notion tách real anchors và inferred anchors.
+3. Dễ debug vì artifacts ghi riêng từng loại.
+4. Có git-delta optimization cho reindex.
+5. Pipeline index khá modular: scanner/detector/extractor/virtual seam pipeline.
+
+---
+
+## 5. Nhược điểm của implementation hiện tại
+
+1. Ở góc nhìn sản phẩm, seam là khái niệm gây nhiễu vì end-user không hề tạo seam.
+2. Planner/generator downstream phải biết branch logic `seams` vs `virtual_seams`.
+3. Output context còn thiếu một artifact hợp nhất kiểu project graph / ownership graph / automatic seam map.
+4. Chưa có public artifact mô tả insertion strategies, ownership, confidence theo mô hình thống nhất.
+5. `code apply` hiện gọi reindex helper theo changed paths, nhưng product contract vẫn chưa được phát biểu rõ là “chạy lại midicoder index”.
+
+---
+
+## 6. Thiết kế v0.2.0
+
+## 6.1 Quyết định sản phẩm
+
+Ở cấp sản phẩm, bỏ cách nói:
+
+- seam
+- virtual seam
+
+Thay bằng:
+
+- **automatic seam map**
+
+Tuy nhiên ở cấp implementation nội bộ, v0.2.0 vẫn có thể giữ real seam marker và inferred seam pipeline như **nguồn tín hiệu** cho automatic seam map.
+
+=> Tức là: **không nhất thiết xóa sạch implementation cũ ngay**, nhưng phải xóa nó khỏi product model public-facing.
+
+## 6.2 Automatic seam map mới
+
+Artifact hợp nhất cần chứa:
+
+- file
+- symbol
+- span / line_start / line_end
+- role
+- insertion_strategy
+- ownership
+- confidence
+- evidence
+
+Nó sẽ được build từ:
+
+- symbols
+- entrypoints
+- exemplars
+- real marker seams
+- inferred virtual seams legacy
+- imports/module graph
+
+## 6.3 Full index / reindex semantics mới
+
+- `midicoder index`: full product contract
+- internal engine có thể dùng incremental optimization
+- sau `code apply`, system luôn phải trigger semantic equivalent của `midicoder index`
+
+---
+
+## 7. Kết luận thiết kế
+
+Phân tích code hiện tại cho thấy điều bạn nêu là đúng:
+
+- end-user không hề đặt seam
+- seam/virtual seam chỉ là implementation detail nội bộ
+- vì vậy docs và product model mới phải chuyển sang `automatic seam map`
+
+Nhưng cũng cần ghi nhận đúng rằng code hiện tại **đã có một pipeline suy luận anchors tự động thật**, chỉ là tên gọi/artifact model của nó chưa hợp lý ở cấp sản phẩm.
+

--- a/plans/v0-2-0/03-backend-codegen/README.md
+++ b/plans/v0-2-0/03-backend-codegen/README.md
@@ -1,0 +1,7 @@
+# Patch 03 - Backend Codegen
+
+Patch thứ ba của v0.2.0 tập trung vào backend-only code generation:
+
+- canonical FastAPI executable code ở `code build`
+- deterministic-first patch planning ở `code gen`
+- pure executor + mandatory reindex ở `code apply`

--- a/plans/v0-2-0/03-backend-codegen/code-apply.md
+++ b/plans/v0-2-0/03-backend-codegen/code-apply.md
@@ -1,0 +1,204 @@
+# Thiết kế command `midicoder code apply` - v0.2.0
+
+## 1. Mục tiêu sản phẩm
+
+`midicoder code apply` là command thực thi patch plan lên workdir thật.
+
+Ở v0.2.0, command này phải là **executor thuần túy**, không chịu trách nhiệm:
+
+- suy luận business logic
+- sáng tác patch
+- tự chọn lại target path
+
+Nó chỉ:
+
+1. load patch plan
+2. validate patch ops
+3. apply tuần tự
+4. ghi file
+5. rollback nếu lỗi
+6. **tự chạy lại `midicoder index` sau apply thành công**
+
+---
+
+## 2. Product contract chốt
+
+### 2.1 Reindex bắt buộc
+
+Ngay sau apply thành công, Midicoder **phải trigger `midicoder index`**.
+
+Không chỉ là internal reindex helper, mà là product guarantee chính thức.
+
+### 2.2 Tại sao không chỉ incremental helper
+
+Vì downstream semantics cần nói rõ:
+
+- context của repo sau apply đã được đồng bộ lại
+- automatic seam map mới đã được rebuild
+- symbol graph mới đã có hiệu lực
+
+Nội bộ có thể optimize bằng changed-path indexing, nhưng command contract là “run index”.
+
+---
+
+## 3. Inputs
+
+1. `patches/index.json`
+2. patch-plan files
+3. working_dir
+4. apply flags
+5. current context manifest (optional for safety)
+
+---
+
+## 4. Outputs
+
+1. updated workdir files
+2. backups
+3. apply report
+4. post-apply index artifacts mới
+5. apply + reindex summary
+
+---
+
+## 5. Primitive operation support
+
+`code apply` phải hỗ trợ primitive ops từ `code gen`:
+
+- create_file
+- replace_file
+- replace_symbol
+- replace_region
+- insert_before_anchor
+- insert_after_anchor
+- append_symbol
+- insert_import
+- delete_symbol
+- update_exports
+
+### Legacy support
+
+- `upsert_region` được support trong giai đoạn chuyển tiếp
+
+---
+
+## 6. Thuật toán cấp cao
+
+### Phase 1 - Load and validate apply queue
+
+1. Load patch index.
+2. Expand queue theo execution order.
+3. Validate schema của mỗi op.
+4. Group ops theo file.
+
+### Phase 2 - Preflight safety checks
+
+1. target file exists/creatable
+2. ownership compatible
+3. anchor exists nếu op yêu cầu
+4. before-hash check nếu có
+5. shared-file policy check
+
+### Phase 3 - Backup
+
+Tạo backup per file trước khi ghi.
+
+### Phase 4 - Apply ops per file
+
+- parse file nếu cần AST-aware op
+- apply ops theo thứ tự đã khai báo
+- validate syntax nếu language adapter có hỗ trợ
+
+### Phase 5 - Commit file writes
+
+- write atomic nếu có thể
+- track changed paths
+
+### Phase 6 - Post-apply verification nhẹ
+
+1. syntax parse
+2. import cycle smoke (optional fast path)
+3. changed file summary
+
+### Phase 7 - Trigger reindex bắt buộc
+
+Gọi lại `midicoder index`.
+
+- Same command semantics
+- Có thể truyền changed paths để optimizer dùng internally
+- Nhưng run artifact phải ghi rõ “index rerun completed/failed”
+
+### Phase 8 - Emit reports
+
+- apply report
+- reindex report
+- final status
+
+---
+
+## 7. Nếu reindex fail thì sao?
+
+### Chính sách v0.2.0
+
+Apply được coi là **chưa hoàn tất đầy đủ** nếu reindex fail.
+
+Status có thể là:
+
+- `applied_and_indexed`
+- `applied_but_reindex_failed`
+- `failed_and_rolled_back`
+
+Mặc định CLI phải coi `applied_but_reindex_failed` là warning-level nghiêm trọng hoặc exit non-zero tùy policy cấu hình.
+
+---
+
+## 8. Idempotency
+
+`code apply` phải gần-idempotent nếu patch plan không đổi và file targets không đổi.
+
+Cụ thể:
+
+- apply lần hai không được duplicate imports/symbols
+- ops phải có no-op detection
+
+---
+
+## 9. Failure modes
+
+1. Patch queue invalid
+2. Anchor missing
+3. Ownership violation
+4. Syntax broken sau apply
+5. Reindex fail
+
+---
+
+## 10. Observability
+
+Báo cáo cần có:
+
+- changed files
+- noop files
+- failed files
+- backups
+- post-apply syntax issues
+- reindex start/end/result
+
+---
+
+## 11. Test strategy
+
+1. Primitive op executor tests
+2. Rollback tests
+3. No-op idempotency tests
+4. Apply + reindex integration tests
+5. Legacy `upsert_region` compatibility tests
+
+---
+
+## 12. Open questions
+
+1. Có nên hard-fail khi reindex fail không?
+2. Có nên cho phép `--no-index` chỉ trong debug mode không?
+3. Có nên hỗ trợ apply transaction theo batch file groups không?
+

--- a/plans/v0-2-0/03-backend-codegen/code-build.md
+++ b/plans/v0-2-0/03-backend-codegen/code-build.md
@@ -1,0 +1,280 @@
+# Thiết kế command `midicoder code build` - v0.2.0
+
+## 1. Mục tiêu sản phẩm
+
+## 1.1 Giới hạn phạm vi của patch set này
+
+Thiết kế trong tài liệu này chỉ tập trung vào **backend**:
+
+- FastAPI/Python backend canonical form
+- modular monolith backend
+- microservice backend
+- large backend applications
+
+Frontend generation/support không thuộc phạm vi patch set v0.2.0 này.
+
+
+`midicoder code build` compile IR thành **canonical FastAPI executable code**. Đây là thay đổi trọng tâm nhất của v0.2.0.
+
+Command này không còn sinh `pseudo_struct` như artifact trung gian chính. Thay vào đó, nó sinh ra:
+
+- canonical Python/FastAPI code blocks hợp lệ
+- ownership metadata
+- insertion anchors
+- contract refs
+- file intent
+
+`pseudo_struct` nếu còn tồn tại chỉ để backward compatibility trong giai đoạn chuyển tiếp.
+
+---
+
+## 2. Vai trò trong pipeline mới
+
+`code build` là compiler backend deterministic từ IR sang canonical code.
+
+### Input
+
+- IR
+- project context graph từ `index`
+
+### Output
+
+- canonical code plan theo file
+- không đụng workdir
+- không generate patch cho workdir thật
+
+---
+
+## 3. Vì sao phải đổi
+
+Hiện trạng metadata-heavy code plan dẫn tới:
+
+1. `code gen` phải tự suy luận quá nhiều.
+2. Boundary build/gen không sạch.
+3. Business logic dễ drift khi model viết code.
+4. Không thể deterministic transform sang stack khác nếu intermediate quá abstract.
+
+---
+
+## 4. Product contract mới
+
+### 4.1 Input artifacts
+
+- `.midicoder/versions/<version>/irs/ir.json`
+- `.midicoder/context/profile.json`
+- `.midicoder/context/automatic_seams.json`
+- `.midicoder/context/symbols.json`
+- `.midicoder/context/entrypoints.json`
+- `.midicoder/context/ownership.json`
+- `.midicoder/context/module_graph.json`
+
+### 4.2 Output artifacts
+
+Thư mục `.midicoder/versions/<version>/plans/` gồm:
+
+- `index.json`
+- `entities/*.code-plan.json`
+- `commands/*.code-plan.json`
+- `queries/*.code-plan.json`
+- `workflows/*.code-plan.json`
+- `bootstrap/*.code-plan.json`
+- `canonical-runtime/` (optional snapshot folder, mới)
+
+---
+
+## 5. Schema code plan mới
+
+```json
+{
+  "schema_version": "0.2.0",
+  "ir_ref": "Command.create_user",
+  "stack": "fastapi",
+  "intent": {...},
+  "canonical_files": [
+    {
+      "runtime_path": "app/users/schema.py",
+      "role": "schema",
+      "language": "python",
+      "framework": "fastapi",
+      "anchors": {
+        "region_start": "# region Command.create_user.schema",
+        "region_end": "# endregion Command.create_user.schema"
+      },
+      "ownership": "owned_generated",
+      "merge_mode": "replace_region",
+      "code": "... python code ...",
+      "contract_refs": {
+        "io": [...],
+        "policy": [...],
+        "workflow": [...],
+        "errors": [...]
+      },
+      "safety": {
+        "can_create_file": true,
+        "can_patch_shared_file": false
+      }
+    }
+  ],
+  "required_tests": [],
+  "meta": {...}
+}
+```
+
+---
+
+## 6. Thuật toán cấp cao
+
+### Phase 1 - Load and normalize inputs
+
+1. Load IR.
+2. Load context graph.
+3. Resolve stack/profile.
+4. Build canonical symbol and ownership indexes.
+
+### Phase 2 - Expand IR items
+
+Chuyển IR thành các build items:
+
+- entities
+- value objects
+- commands
+- queries
+- workflows
+- projections
+- bootstrap/runtime infra
+
+### Phase 3 - Resolve canonical runtime file set
+
+Không resolve bằng `seam/virtual seam` branch logic nữa.
+Thay vào đó dùng:
+
+- automatic seam map
+- ownership graph
+- file conventions
+- route/service/model role mapping
+
+### Phase 4 - Deterministic emitters
+
+Tách emitter theo role:
+
+1. controller_fastapi
+2. service_fastapi
+3. schema_fastapi
+4. model_fastapi
+5. repository_fastapi
+6. workflow_fastapi
+7. bootstrap_fastapi
+8. infra_fastapi
+9. tests_fastapi (optional future)
+
+### Phase 5 - Canonical code validation
+
+1. parse AST
+2. import validity (in canonical namespace)
+3. route/io contract integrity
+4. workflow semantics presence
+5. policy/guard checkpoints presence
+6. no TODO/placeholder
+
+### Phase 6 - Ownership + patch safety hints
+
+Mỗi canonical file phải gắn:
+
+- ownership class
+- merge mode suggestion
+- safe patch strategies
+- preferred insertion targets
+
+### Phase 7 - Persist plans
+
+Write per-item code-plan JSON + plan index.
+
+---
+
+## 7. Có phải “real code” không?
+
+Có, theo nghĩa:
+
+- code hợp lệ Python/FastAPI
+- parse được AST
+- có thể materialize và chạy lint/typecheck ở mức cơ bản
+
+Không, theo nghĩa:
+
+- chưa chắc đúng style repo đích
+- chưa chắc tối ưu cho codebase hiện hữu
+- chưa chắc là production-final implementation
+
+Do đó khái niệm chính xác là:
+
+- **canonical executable code**
+
+---
+
+## 8. Vì sao vẫn chọn canonical FastAPI làm intermediate
+
+1. Python/FastAPI dễ canonical hóa.
+2. Dễ encode workflows/API/service/model/repository.
+3. Dễ parse AST và transform deterministic.
+4. Dễ dịch sang stack khác hơn từ metadata trừu tượng.
+
+---
+
+## 9. Determinism
+
+`code build` v0.2.0 phải:
+
+- không gọi LLM
+- cùng input -> cùng output byte-for-byte (trừ timestamp metadata nếu có)
+- có snapshot hash tests
+
+---
+
+## 10. Failure modes
+
+1. IR thiếu semantics tối thiểu
+2. Context graph không đủ để map ownership/path
+3. Emitter không sinh được code hợp lệ
+4. Canonical code conflict trên same file/role
+
+### Policy khi fail
+
+- fail sớm
+- emit diagnostics
+- không fallback sang LLM
+
+---
+
+## 11. Migration strategy
+
+### 11.1 Phase chuyển tiếp
+
+Có thể giữ:
+
+- `pseudo_struct`
+- `integration_contract`
+
+nhưng deprecated.
+
+### 11.2 Phase ổn định
+
+Downstream phải đọc `canonical_files` trước.
+
+---
+
+## 12. Test strategy
+
+1. Determinism tests
+2. AST parse tests
+3. Route/policy/workflow integrity tests
+4. Ownership mapping tests
+5. Multi-module SaaS sample tests
+
+---
+
+## 13. Open questions
+
+1. Có nên emit canonical unit tests ngay từ code build không?
+2. Repository layer có nên luôn explicit hay infer theo persistence needs?
+3. Có nên có canonical dependency injection spec riêng không?
+

--- a/plans/v0-2-0/03-backend-codegen/code-gen.md
+++ b/plans/v0-2-0/03-backend-codegen/code-gen.md
@@ -1,0 +1,253 @@
+# Thiết kế command `midicoder code gen` - v0.2.0
+
+## 1. Mục tiêu sản phẩm
+
+## 1.1 Giới hạn phạm vi của patch set này
+
+Thiết kế trong tài liệu này chỉ tập trung vào **backend**:
+
+- FastAPI/Python backend canonical form
+- modular monolith backend
+- microservice backend
+- large backend applications
+
+Frontend generation/support không thuộc phạm vi patch set v0.2.0 này.
+
+
+`midicoder code gen` nhận:
+
+- canonical FastAPI code từ `code build`
+- project context graph từ `index`
+- code thật trong workdir
+
+và sinh ra **patch plan** để cập nhật workdir đích hoặc target stack đích.
+
+Trong v0.2.0, command này **không còn là nơi “sáng tác business logic”**.
+
+---
+
+## 2. Product goals
+
+1. Dùng canonical code làm nguồn sự thật cho implementation semantics.
+2. Ưu tiên deterministic patch planning.
+3. Chỉ dùng model như fallback adapter khi deterministic translator không đủ.
+4. Tách rõ same-stack integration và cross-stack translation.
+
+---
+
+## 3. Non-goals
+
+1. Không generate business intent mới.
+2. Không tự bịa file targets ngoài ownership/context model.
+3. Không áp patch vào workdir.
+
+---
+
+## 4. Input
+
+1. plan index + plan files có `canonical_files[]`
+2. context graph (`automatic_seams`, symbols, ownership, imports, profile, module graph)
+3. current workdir snapshot
+4. target stack config
+
+---
+
+## 5. Output
+
+`.midicoder/versions/<version>/patches/` gồm:
+
+- `index.json`
+- `*.patch-plan.json`
+- `patch-report.json`
+- optional `runtime/` preview files
+
+---
+
+## 6. Chế độ hoạt động
+
+### 6.1 Mode A - same-stack deterministic
+
+Canonical FastAPI -> workdir FastAPI/Python
+
+Đây là mode mặc định ưu tiên.
+
+### 6.2 Mode B - cross-stack deterministic translator
+
+Canonical FastAPI -> target stack có adapter deterministic
+
+Ví dụ tương lai:
+
+- NestJS
+- Django
+- Flask
+- gRPC service skeleton
+
+### 6.3 Mode C - fallback model adapter
+
+Chỉ dùng khi:
+
+- target stack chưa có deterministic adapter đầy đủ
+- repo có integration pattern quá dị biệt
+- deterministic planner confidence dưới threshold
+
+---
+
+## 7. Thuật toán cấp cao
+
+### Phase 1 - Load plan and context
+
+1. Load plan manifest.
+2. Resolve execution order.
+3. Load workdir symbol graph snapshot.
+4. Load automatic seam map + ownership graph.
+
+### Phase 2 - For each canonical file, resolve integration target
+
+Từ `canonical_files[]`, xác định:
+
+- target file thật trong workdir
+- target symbol/anchor
+- patch mode
+- import strategy
+- conflict policy
+
+### Phase 3 - Deterministic patch synthesis
+
+Nếu same-stack hoặc có adapter deterministic:
+
+1. Parse canonical AST
+2. Parse target AST/file text
+3. Match symbol ownership
+4. Generate primitive patch ops
+   - create_file
+   - replace_symbol
+   - replace_region
+   - insert_import
+   - append_symbol
+   - update_init_export
+
+### Phase 4 - Optional model fallback
+
+Chỉ nếu deterministic synthesis không khả thi.
+Model được phép làm:
+
+- structural adaptation
+- repo-style alignment
+- cross-stack translation
+
+Model không được phép:
+
+- đổi business semantics
+- đổi IO contract
+- bỏ policy/workflow checkpoints
+
+### Phase 5 - Validation
+
+1. patch plan schema validity
+2. target path safety
+3. import consistency
+4. ownership safety
+5. circular dependency check
+6. contract-preservation check
+
+### Phase 6 - Persist patch plans
+
+Write patch-plan JSON + report.
+
+---
+
+## 8. Primitive patch op model mới
+
+Patch plan v0.2.0 nên ưu tiên primitive ops thay vì generic `upsert_region` duy nhất.
+
+### Ops đề xuất
+
+- `create_file`
+- `replace_file`
+- `replace_symbol`
+- `replace_region`
+- `insert_before_anchor`
+- `insert_after_anchor`
+- `append_symbol`
+- `insert_import`
+- `delete_symbol`
+- `update_exports`
+
+Mỗi op cần có:
+
+- target path
+- selector / anchor
+- ownership expectation
+- before-hash optional
+- content payload
+- rollback safety
+
+---
+
+## 9. Vì sao `code gen` vẫn cần context graph + workdir code
+
+Dù canonical code đã rõ, integration vào repo thật vẫn cần:
+
+1. biết file nào là owned/shared/unsafe
+2. biết module nào đang tồn tại
+3. biết import graph hiện tại
+4. biết entrypoint wiring thực tế
+5. biết style/package layout của repo
+
+Do đó `code gen` là **context-aware integration compiler**, không chỉ translator thuần túy.
+
+---
+
+## 10. Determinism strategy
+
+### Mặc định
+
+- deterministic path resolution
+- deterministic patch op synthesis
+- deterministic import ordering
+- deterministic conflict diagnostics
+
+### Khi nào được dùng model
+
+Chỉ khi:
+
+- adapter coverage thiếu
+- conflict resolution ambiguity cao
+- cross-stack mapping chưa codify đủ
+
+và phải có feature flag explicit.
+
+---
+
+## 11. Failure modes
+
+1. Không resolve được safe target file
+2. Shared file không có safe anchor
+3. Cross-stack adapter thiếu coverage
+4. Patch plan làm đổi contract semantics
+5. Ownership conflict
+
+### Policy khi fail
+
+- emit blocked patch report
+- không fallback ngầm sang LLM
+- yêu cầu index/build/adapter coverage tốt hơn
+
+---
+
+## 12. Test strategy
+
+1. Same-stack deterministic generation tests
+2. AST-based patch op tests
+3. Ownership conflict tests
+4. Cross-stack translation tests
+5. Contract preservation tests
+
+---
+
+## 13. Open questions
+
+1. Nên normalize canonical AST trước khi translate không?
+2. Nên có IR-level adapter thay vì code-level adapter cho một số stack không?
+3. Shared file patching có nên yêu cầu explicit allowlist?
+

--- a/plans/v0-2-0/04-runtime-quality/README.md
+++ b/plans/v0-2-0/04-runtime-quality/README.md
@@ -1,0 +1,8 @@
+# Patch 04 - Runtime Quality
+
+Patch thứ tư của v0.2.0 tập trung vào:
+
+- verification pipeline thật cho backend runtime/test quality
+- generated tests từ DSL/contracts
+- coverage threshold >= 85%
+- deterministic remediation orchestration ở `runtime fix`

--- a/plans/v0-2-0/04-runtime-quality/runtime-fix.md
+++ b/plans/v0-2-0/04-runtime-quality/runtime-fix.md
@@ -1,0 +1,266 @@
+# Thiết kế command `midicoder runtime fix` - v0.2.0
+
+## 1. Mục tiêu sản phẩm
+
+`midicoder runtime fix` không còn là LLM patch generator. Trong v0.2.0, nó là **deterministic remediation orchestrator**.
+
+Nhiệm vụ của command:
+
+1. đọc kết quả verification failures
+2. phân loại lỗi theo tầng
+3. xác định lỗi thuộc implementation, contract, test-generation hay brief
+4. tạo remediation brief/task set
+5. tạo version mới
+6. chạy lại pipeline từ pha thích hợp
+
+---
+
+## 2. Vì sao phải bỏ LLM ở runtime fix
+
+Runtime fix kiểu LLM patching có nhược điểm:
+
+1. fix cục bộ nhưng không sửa nguồn gốc pipeline
+2. dễ drift business semantics
+3. khó audit
+4. khó hội tụ khi lỗi lặp lại
+
+Hướng mới là:
+
+- sửa từ upstream artifact phù hợp
+- để compiler pipeline generate lại có kiểm soát
+
+---
+
+## 3. Input
+
+1. verification summary mới nhất
+2. workdir snapshot
+3. current version artifacts
+4. prior remediation attempts
+5. context graph hiện tại
+
+---
+
+## 4. Output
+
+1. remediation report
+2. remediation classification artifact
+3. remediation brief hoặc remediation task bundle
+4. version mới
+5. pipeline rerun summary
+
+---
+
+## 5. Error classification model
+
+### Class A - implementation defect
+
+Ví dụ:
+
+- import lỗi
+- syntax lỗi
+- typecheck fail
+- unit test fail do implementation
+- missing wiring
+
+### Class B - architecture/integration defect
+
+Ví dụ:
+
+- wrong ownership target
+- bad patch target
+- module boundary violation
+- service graph mismatch
+
+### Class C - contract defect
+
+Ví dụ:
+
+- request/response contract sai
+- workflow semantics thiếu
+- policy semantics sai
+
+### Class D - brief defect
+
+Ví dụ:
+
+- requirement gốc mâu thuẫn
+- business intent thiếu hoặc sai
+
+---
+
+## 6. Remediation routing
+
+### Nếu Class A
+
+Tạo implementation remediation task và rerun từ:
+
+- `code build` hoặc `code gen` tùy mức ảnh hưởng
+
+### Nếu Class B
+
+Tạo integration remediation task và rerun từ:
+
+- `index` hoặc `code gen`
+
+### Nếu Class C
+
+Tạo remediation brief + contract patch set và rerun từ:
+
+- `contract repair` hoặc `contract gen` scoped
+
+### Nếu Class D
+
+Tạo remediation brief mới và rerun từ:
+
+- `brief rewrite`
+
+---
+
+## 7. Thuật toán cấp cao
+
+### Phase 1 - Load verification artifacts
+
+1. Read verify-summary
+2. Load stage logs
+3. Normalize errors
+
+### Phase 2 - Root-cause classification
+
+1. map failure -> affected files
+2. map files -> contracts/IR refs/modules/services
+3. classify upstream defect layer
+
+### Phase 3 - Build remediation artifact
+
+Artifact có thể gồm:
+
+- remediation brief
+- remediation task set
+- impacted modules list
+- preserved invariants
+
+### Phase 4 - Create new version
+
+Không sửa trực tiếp version hiện tại theo cách opaque.
+
+- create new version
+- carry forward approved artifacts cần thiết
+- attach remediation metadata
+
+### Phase 5 - Rerun pipeline
+
+Chạy lại từ phase tương ứng.
+
+### Phase 6 - Compare results
+
+1. failure reduced?
+2. new regressions introduced?
+3. convergence status?
+
+---
+
+## 8. Remediation brief format
+
+```json
+{
+  "mode": "remediation",
+  "source_version": "v123",
+  "failure_classes": ["implementation_defect"],
+  "preserve_invariants": [
+    "Không đổi public API contract create_user",
+    "Không đổi workflow state transitions"
+  ],
+  "corrective_goals": [
+    "Sửa wiring DB session trong app/shared/db.py",
+    "Loại bỏ circular import giữa app.users.service và app.main"
+  ],
+  "evidence": {
+    "verify_summary": "...",
+    "changed_files": []
+  }
+}
+```
+
+---
+
+## 9. Không dùng LLM
+
+Runtime fix v0.2.0 phải chạy hoàn toàn deterministic.
+
+Nếu remediation brief cần ngôn ngữ tự nhiên đẹp hơn, có thể sinh template deterministic từ error classes. Không phụ thuộc model.
+
+---
+
+## 10. Hội tụ vòng lặp
+
+Hệ thống phải track:
+
+- iteration count
+- error signature history
+- failure reduction score
+- repeated-failure threshold
+
+Nếu vượt threshold mà không hội tụ:
+
+- stop auto loop
+- emit escalation report
+
+---
+
+## 11. Failure modes
+
+1. classifier không đủ bằng chứng root cause
+2. remediation route chọn sai phase
+3. rerun tạo regressions lớn hơn
+4. loop không hội tụ
+
+### Policy
+
+- stop with escalation artifact
+- không patch trực tiếp workdir bằng heuristic mù
+
+---
+
+## 12. Observability
+
+Artifacts bắt buộc:
+
+- remediation-classification.json
+- remediation-brief.md / .json
+- rerun-plan.json
+- convergence-report.json
+- version lineage report
+
+---
+
+## 13. Test strategy
+
+1. Error classification tests
+2. Routing tests implementation vs contract vs brief
+3. Version lineage tests
+4. Auto-loop convergence tests
+5. Escalation threshold tests
+
+---
+
+## 14. Open questions
+
+1. Có nên cho runtime fix chạy scoped pipeline song song theo service không?
+2. Có nên lưu diff giữa old/new brief trong remediation mode không?
+3. Có nên có confidence score để quyết định auto-rerun hay manual review?
+
+
+
+## 15. Quan hệ với generated tests
+
+Vì v0.2.0 yêu cầu DSL hỗ trợ full test generation, `runtime fix` phải hiểu thêm một lớp lỗi mới:
+
+- test_generation_defect
+- insufficient_coverage
+
+Nếu lỗi đến từ generated tests hoặc coverage < 85%, remediation route mặc định không phải patch tay testcase trong workdir, mà là quay về upstream artifact phù hợp:
+
+- contract/test DSL
+- IR test intents
+- canonical backend code/test build outputs

--- a/plans/v0-2-0/04-runtime-quality/runtime-test.md
+++ b/plans/v0-2-0/04-runtime-quality/runtime-test.md
@@ -1,0 +1,216 @@
+# Thiết kế command `midicoder runtime test` - v0.2.0
+
+## 1. Mục tiêu sản phẩm
+
+`midicoder runtime test` không còn chỉ là “chạy app lên xem có boot được không”. Trong v0.2.0, command này trở thành **verification pipeline thật** cho workdir sau apply. Pipeline này phải dùng cả **generated test suite từ DSL/contracts** và enforce mục tiêu coverage tối thiểu **85%** cho backend scope được generate.
+
+---
+
+## 2. Vì sao phải đổi
+
+Startup smoke test chỉ phát hiện được một lớp lỗi hẹp:
+
+- import errors
+- syntax errors
+- boot-time runtime errors
+
+Nhưng không bắt được đầy đủ:
+
+- lint violations
+- type errors
+- test regressions
+- API contract mismatches
+- broken behavior trong unit/integration tests
+
+---
+
+## 3. Product contract mới
+
+`runtime test` => `verify pipeline`
+
+### Verification stages mặc định
+
+1. environment check
+2. format/lint
+3. static typecheck
+4. unit test
+5. integration/smoke test
+6. optional app startup
+
+---
+
+## 4. Inputs
+
+1. working_dir
+2. stack profile từ index
+3. verification config
+4. changed paths (optional optimization)
+
+---
+
+## 5. Outputs
+
+Thư mục logs / verification artifacts:
+
+- `verify-summary.json`
+- `lint.log`
+- `typecheck.log`
+- `unit.log`
+- `integration.log`
+- `smoke.log`
+- `failure-classification.json`
+
+---
+
+## 6. Stage design
+
+### Stage A - Environment readiness
+
+Kiểm tra:
+
+- python/node runtime
+- virtual env / package manager
+- dependency install state
+- required env vars tối thiểu
+
+### Stage B - Lint
+
+Ví dụ Python:
+
+- `ruff check`
+- optional `ruff format --check`
+
+### Stage C - Typecheck
+
+Ví dụ Python:
+
+- `mypy`
+- hoặc `pyright`
+
+### Stage D - Unit tests
+
+Ví dụ:
+
+- `pytest -q`
+
+### Stage E - Integration tests
+
+Nếu repo có marker/config tương ứng:
+
+- API tests
+- service integration tests
+- DB migration smoke
+
+### Stage F - Startup smoke
+
+Cuối cùng mới boot app nếu phù hợp.
+
+---
+
+## 7. Error classification
+
+Mọi lỗi phải được phân loại thành machine-readable categories:
+
+- environment_error
+- dependency_error
+- lint_error
+- type_error
+- unit_test_failure
+- integration_test_failure
+- startup_error
+- contract_drift_signal
+
+---
+
+## 8. Changed-path optimization
+
+Nếu vừa `code apply`, command có thể ưu tiên:
+
+- lint/typecheck/test impacted areas trước
+- nhưng vẫn cần policy rõ về full verification vs fast verification
+
+### Chế độ đề xuất
+
+- `--fast`: chỉ impacted checks
+- `--full`: full suite
+
+Mặc định CI hoặc automated remediation nên dùng `--full`.
+
+---
+
+## 9. Không dùng LLM
+
+Command này phải hoàn toàn deterministic.
+
+---
+
+## 10. Failure modes
+
+1. tooling missing
+2. test runner misconfigured
+3. flaky tests
+4. env secrets missing
+5. startup dependency unavailable
+
+### Policy khi fail
+
+- phân biệt infra failure và code failure
+- emit actionable diagnostics
+- không tự patch code
+
+---
+
+## 11. Observability
+
+Mỗi stage cần:
+
+- command line executed
+- start/end time
+- exit code
+- stdout/stderr logs
+- normalized error summaries
+
+---
+
+## 12. Test strategy cho command
+
+1. Stage orchestration tests
+2. Error classification tests
+3. Fast vs full mode tests
+4. Missing tool diagnostics tests
+
+---
+
+## 13. Open questions
+
+1. Có nên hỗ trợ multi-service verification matrix không?
+2. Có nên detect test impact graph từ changed files không?
+3. Có nên cho phép custom verification pipelines per stack không?
+
+
+
+## 14. Generated tests và coverage policy
+
+### 14.1 Test suite nguồn gốc từ DSL
+
+`runtime test` không chỉ chạy test mà developer tự viết tay. Ở v0.2.0 nó phải tiêu thụ cả test suite được sinh từ contracts/DSL, gồm:
+
+- unit tests cho application/domain logic
+- integration tests cho persistence/integration boundaries
+- API tests cho HTTP contracts
+- authorization/policy tests
+- workflow transition tests
+
+### 14.2 Coverage target
+
+- Mục tiêu mặc định của patch set này là **>= 85% code coverage** cho backend generated scope.
+- Coverage phải được đo và ghi artifact riêng.
+- Nếu coverage dưới ngưỡng, `runtime test` phải fail hoặc warning-hard theo policy cấu hình.
+
+### 14.3 Artifact bổ sung
+
+Cần bổ sung:
+
+- `coverage.xml` hoặc tương đương
+- `coverage-summary.json`
+- mapping từ generated test suite -> DSL contract refs


### PR DESCRIPTION
### Motivation

- Implement a major v0.2.0 architecture redesign that shifts toward deterministic compiler pipelines, reduces LLM reliance to contract generation, and focuses on backend/microservice scalability and testability. 
- Define canonical FastAPI executable code as the primary backend IR, replace user-facing `seams`/`virtual_seams` with an `automatic seam map`, and enforce verification-first remediation and mandatory reindexing after applying patches. 
- Require DSL/IR extensions to support large SaaS/multi-service scenarios and full test generation with a target coverage threshold of `>= 85%` for generated backend tests.

### Description

- Add a new `plans/v0-2-0` design folder with `00-overview/README.md` and detailed command-level design documents under `01-contract-foundation/`, `02-index-context/`, `03-backend-codegen/`, and `04-runtime-quality/` covering `brief rewrite`, `contract gen/check/repair`, `index`, `code build/gen/apply`, and `runtime test/fix`. 
- Specify key product decisions: `code build` emits canonical FastAPI Python code plans (no LLM, deterministic), `code gen` produces deterministic patch plans from canonical code and the project context graph with model fallback only when necessary, and `code apply` is a pure executor that must trigger `midicoder index` after successful apply. 
- Define `automatic_seams.json`/project context graph as the unified indexing artifact replacing public seam concepts and introduce a primitive patch op model (`create_file`, `replace_symbol`, `replace_region`, `insert_import`, etc.), canonical plan schemas, and verification artifacts for the runtime test pipeline. 
- Design `runtime test` as a true verification pipeline (lint, typecheck, unit/integration tests, coverage reporting) and `runtime fix` as a deterministic remediation orchestrator that classifies failures and reruns the pipeline from the appropriate phase.

### Testing

- No automated tests were run as part of this PR because the change is documentation and design artifacts only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbf380a4a88326a6843bd5e12b4232)