### PR TITLE
[WIP] feat: backend api for webgui

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,188 @@
+# Midicoder WebGUI API
+
+API Server cho Midicoder WebGUI - CLI Wrapper bằng FastAPI.
+
+## 🎯 Mục đích
+
+API đóng vai trò cầu nối giữa WebGUI (Angular frontend) và Midicoder CLI, cung cấp HTTP endpoints để gọi các commands CLI.
+
+## 📋 Yêu cầu
+
+- Python 3.11+
+- Các dependencies trong `requirements.txt`
+
+## 🚀 Cài đặt
+
+```bash
+# Cài đặt dependencies
+pip install -r requirements.txt
+```
+
+## ⚡ Khởi động
+
+### Trước tiên: Init dự án (bắt buộc)
+
+API load CWD từ file `~/.midicoder/midicoder.json`. File này được tạo bởi command `midicoder init`:
+
+```bash
+midicoder init
+```
+
+### Cách 1: Dùng script (khuyến nghị)
+
+```bash
+# Windows
+start_api.bat
+```
+
+### Cách 2: Chạy bằng terminal
+
+```bash
+cd api
+set PYTHONPATH=%cd%;%PYTHONPATH%
+python -m uvicorn app.main:app --host 0.0.0.0 --port 6868
+```
+
+## 🌐 Truy cập
+
+| URL | Mô tả |
+|-----|-------|
+| http://localhost:6868/docs | Swagger UI (interative testing) |
+| http://localhost:6868/redoc | ReDoc documentation |
+| http://localhost:6868/api/health/status | Kiểm tra status và CWD |
+
+## 🔌 Endpoints
+
+### Health
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| GET | `/api/health/` | Health check |
+| GET | `/api/health/ready` | Ready check |
+| GET | `/api/health/info` | API info |
+| GET | `/api/health/languages` | Danh sách ngôn ngữ |
+| GET | `/api/health/status` | Status và CWD hiện tại |
+
+### Config
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| GET | `/api/config/list` | Liệt kê config |
+| GET | `/api/config/get/{key}` | Lấy giá trị config |
+| POST | `/api/config/set` | Đặt giá trị config |
+| POST | `/api/config/validate` | Validate config |
+| POST | `/api/config/reset` | Reset config |
+
+### Index
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| POST | `/api/index/` | Build index |
+| POST | `/api/index/reindex` | Reindex files |
+
+### Version
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| POST | `/api/version/create` | Tạo phiên bản mới |
+
+### Brief
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| POST | `/api/brief/analyze` | Phân tích brief |
+| POST | `/api/brief/rewrite` | Viết lại brief |
+
+### Contract
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| POST | `/api/contract/gen` | Generate contract |
+| POST | `/api/contract/gen/resume` | Resume contract gen |
+| POST | `/api/contract/check` | Kiểm tra contract |
+| POST | `/api/contract/feedback` | Feedback cho contract |
+
+### IR
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| POST | `/api/ir/build` | Build MIR |
+
+### Code
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| POST | `/api/code/build` | Build code plan |
+| POST | `/api/code/plan` | Plan code |
+| POST | `/api/code/gen` | Generate code |
+| POST | `/api/code/apply` | Apply code |
+
+### Runtime
+| Method | Endpoint | Mô tả |
+|--------|----------|-------|
+| POST | `/api/runtime/test` | Test runtime |
+| POST | `/api/runtime/fix` | Fix runtime errors |
+
+## 🌍 Đa ngôn ngữ (i18n)
+
+API hỗ trợ 2 ngôn ngữ:
+- **Tiếng Việt (vi)** - Mặc định
+- **Tiếng Anh (en)**
+
+Override ngôn ngữ bằng header:
+```bash
+curl -H "X-Lang: en" http://localhost:6868/
+```
+
+## 📁 Cấu trúc
+
+```
+api/
+├── app/
+│   ├── __init__.py
+│   ├── main.py          # FastAPI application
+│   ├── config.py        # Cấu hình + load CWD
+│   ├── i18n.py          # Đa ngôn ngữ
+│   ├── models.py        # Pydantic models
+│   ├── cli_wrapper.py   # CLI wrapper
+│   └── routers/
+│       ├── __init__.py
+│       ├── health.py
+│       ├── config.py
+│       ├── index.py
+│       ├── version.py
+│       ├── brief.py
+│       ├── contract.py
+│       ├── ir.py
+│       ├── code.py
+│       └── runtime.py
+├── requirements.txt
+├── start_api.bat
+└── README.md
+```
+
+## 🔧 Đổi CWD
+
+API chỉ làm việc trên một CWD duy nhất cùng lúc. Để đổi CWD:
+
+```bash
+midicoder config set cwd "new-project-path"
+```
+
+Sau đó restart API server.
+
+## 🧪 Test
+
+```bash
+# Kiểm tra status và CWD
+curl http://localhost:6868/api/health/status
+
+# Test i18n - Tiếng Anh
+curl -H "X-Lang: en" http://localhost:6868/
+
+# Test health check
+curl http://localhost:6868/api/health/
+```
+
+## 📝 Lưu ý
+
+- **Không có endpoint `/api/init/`**: User phải chạy `midicoder init` bằng CLI trước khi dùng API
+- API load CWD tự động từ `~/.midicoder/midicoder.json`
+- CLI wrapper thuần túy, không thêm logic business
+- Tất cả comment trong code bằng tiếng Việt
+
+## 📄 License
+
+MIT

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,3 @@
+"""
+Midicoder WebGUI API - CLI Wrapper cho Midicoder
+"""

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,0 +1,6 @@
+"""
+Midicoder WebGUI API Application
+CLI Wrapper cho Midicoder commands
+"""
+
+__version__ = "1.0.0"

--- a/api/app/cli_wrapper.py
+++ b/api/app/cli_wrapper.py
@@ -1,0 +1,320 @@
+"""
+CLI Wrapper cho Midicoder
+Wrapper thuần túy - chỉ gọi CLI mà không thêm logic nào
+Tất cả comment bằng tiếng Việt
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from app.config import settings, get_project_cwd
+from app.i18n import i18n
+
+
+class CLIWrapper:
+    """
+    Wrapper để gọi CLI commands của Midicoder
+    Không thêm logic business, chỉ đóng vai trò cầu nối
+    """
+    
+    def __init__(self):
+        # Thêm đường dẫn đến midicoder vào sys.path
+        # Đảm bảo có thể import midicoder
+        sys.path.insert(0, str(Path(__file__).parent.parent.parent.resolve()))
+    
+    def _build_command_args(
+        self,
+        command: str,
+        subcommand: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None
+    ) -> list[str]:
+        """
+        Xây dựng đối số cho CLI command
+        
+        Args:
+            command: Tên command chính (init, config, brief, v.v.)
+            subcommand: Subcommand (nếu có)
+            args: Các đối số bổ sung
+        
+        Returns:
+            Danh sách đối số cho CLI
+        """
+        cmd_args = ["python", "-m", "midicoder"]
+        
+        # Thêm command
+        cmd_args.append(command)
+        
+        # Thêm subcommand nếu có
+        if subcommand:
+            cmd_args.append(subcommand)
+        
+        # Thêm các đối số từ args dict
+        if args:
+            for key, value in args.items():
+                # Chuyển underscore thành hyphen (--my_arg -> --my-arg)
+                arg_name = f"--{key.replace('_', '-')}"
+                
+                # Xử lý giá trị boolean
+                if isinstance(value, bool):
+                    if value:
+                        cmd_args.append(arg_name)
+                elif isinstance(value, list):
+                    # Xử lý danh sách
+                    for item in value:
+                        cmd_args.append(arg_name)
+                        cmd_args.append(str(item))
+                else:
+                    # Giá trị thường
+                    cmd_args.append(arg_name)
+                    cmd_args.append(str(value))
+        
+        return cmd_args
+    
+    async def execute_command(
+        self,
+        command: str,
+        subcommand: Optional[str] = None,
+        args: Optional[Dict[str, Any]] = None,
+        timeout: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """
+        Thực thi một CLI command
+        
+        Args:
+            command: Tên command (config, brief, contract, ir, code, runtime)
+            subcommand: Subcommand (nếu có)
+            args: Các đối số cho command
+            timeout: Timeout tính bằng giây (mặc định từ settings)
+        
+        Returns:
+            Dict chứa kết quả thực thi
+        """
+        if timeout is None:
+            timeout = settings.cli_timeout
+        
+        # Xây dựng command args
+        cmd_args = self._build_command_args(command, subcommand, args)
+        
+        # Thiết lập môi trường
+        env = os.environ.copy()
+        
+        # Thiết lập thư mục làm việc từ global config
+        cwd = get_project_cwd()
+        
+        try:
+            # Tạo subprocess
+            process = await asyncio.create_subprocess_exec(
+                *cmd_args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+            )
+            
+            # Đọc output với timeout
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=timeout
+                )
+                
+                exit_code = process.returncode
+                
+                # Decode output
+                stdout_text = stdout.decode('utf-8', errors='replace')
+                stderr_text = stderr.decode('utf-8', errors='replace')
+                
+                # Parse output nếu là JSON
+                stdout_data = None
+                try:
+                    stdout_data = json.loads(stdout_text) if stdout_text.strip() else None
+                except json.JSONDecodeError:
+                    pass
+                
+                return {
+                    "success": exit_code == 0,
+                    "exit_code": exit_code,
+                    "stdout": stdout_text,
+                    "stdout_data": stdout_data,
+                    "stderr": stderr_text,
+                    "command": cmd_args,
+                }
+                
+            except asyncio.TimeoutError:
+                # Kill process nếu timeout
+                process.kill()
+                await process.wait()
+                
+                return {
+                    "success": False,
+                    "exit_code": -1,
+                    "stdout": "",
+                    "stderr": f"Command timed out after {timeout} seconds",
+                    "command": cmd_args,
+                    "timeout": True,
+                }
+                
+        except FileNotFoundError:
+            return {
+                "success": False,
+                "exit_code": -1,
+                "stdout": "",
+                "stderr": "Midicoder command not found. Ensure midicoder is installed.",
+                "command": cmd_args,
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "exit_code": -1,
+                "stdout": "",
+                "stderr": str(e),
+                "command": cmd_args,
+            }
+    
+    # ==================== Config Commands ====================
+    
+    async def config_get(self, key: str) -> Dict[str, Any]:
+        """Lấy giá trị config"""
+        return await self.execute_command("config", "get", {key: None})
+    
+    async def config_set(self, key: str, value: str) -> Dict[str, Any]:
+        """Đặt giá trị config"""
+        return await self.execute_command("config", "set", {key: value})
+    
+    async def config_list(self) -> Dict[str, Any]:
+        """Liệt kê tất cả config"""
+        return await self.execute_command("config", "list")
+    
+    async def config_validate(self) -> Dict[str, Any]:
+        """Validate config"""
+        return await self.execute_command("config", "validate")
+    
+    async def config_reset(self) -> Dict[str, Any]:
+        """Reset config về mặc định"""
+        return await self.execute_command("config", "reset")
+    
+    # ==================== Index Commands ====================
+    
+    async def index_build(self) -> Dict[str, Any]:
+        """Build index"""
+        return await self.execute_command("index")
+    
+    async def index_reindex(self, paths: Optional[list[str]] = None) -> Dict[str, Any]:
+        """Reindex các file đã thay đổi"""
+        args = {"path": paths} if paths else {}
+        return await self.execute_command("index", "reindex", args)
+    
+    # ==================== Version Commands ====================
+    
+    async def version_create(self, version: str) -> Dict[str, Any]:
+        """Tạo phiên bản mới"""
+        return await self.execute_command("version", "create", {"version": version})
+    
+    # ==================== Brief Commands ====================
+    
+    async def brief_analyze(self) -> Dict[str, Any]:
+        """Phân tích brief"""
+        return await self.execute_command("brief", "analyze")
+    
+    async def brief_rewrite(self) -> Dict[str, Any]:
+        """Viết lại brief"""
+        return await self.execute_command("brief", "rewrite")
+    
+    # ==================== Contract Commands ====================
+    
+    async def contract_gen(self) -> Dict[str, Any]:
+        """Generate contract"""
+        return await self.execute_command("contract", "gen")
+    
+    async def contract_gen_resume(self) -> Dict[str, Any]:
+        """Resume contract generation"""
+        return await self.execute_command("contract", "gen", {"resume": None})
+    
+    async def contract_check(self) -> Dict[str, Any]:
+        """Kiểm tra contract"""
+        return await self.execute_command("contract", "check")
+    
+    async def contract_feedback(self) -> Dict[str, Any]:
+        """Feedback cho contract"""
+        return await self.execute_command("contract", "feedback")
+    
+    # ==================== IR Commands ====================
+    
+    async def ir_build(self, skip_diagrams: bool = False) -> Dict[str, Any]:
+        """Build IR (MIR)"""
+        return await self.execute_command("ir", "build", {"skip_diagrams": skip_diagrams})
+    
+    # ==================== Code Commands ====================
+    
+    async def code_build(self) -> Dict[str, Any]:
+        """Build code plan"""
+        return await self.execute_command("code", "build")
+    
+    async def code_plan(self) -> Dict[str, Any]:
+        """Plan code (alias của build)"""
+        return await self.execute_command("code", "plan")
+    
+    async def code_gen(self, runtime: bool = False) -> Dict[str, Any]:
+        """Generate code"""
+        return await self.execute_command("code", "gen", {"runtime": runtime})
+    
+    async def code_apply(
+        self,
+        force: bool = False,
+        dry_run: bool = False,
+        no_reindex: bool = False,
+        patches_subdir: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Apply code"""
+        args = {
+            "force": force,
+            "dry_run": dry_run,
+            "no_reindex": no_reindex,
+        }
+        if patches_subdir:
+            args["patches_dir"] = patches_subdir
+        return await self.execute_command("code", "apply", args)
+    
+    # ==================== Runtime Commands ====================
+    
+    async def runtime_test(
+        self,
+        timeout: int = 30,
+        port: int = 8000,
+        verbose: bool = False
+    ) -> Dict[str, Any]:
+        """Test runtime"""
+        return await self.execute_command("runtime", "test", {
+            "timeout": timeout,
+            "port": port,
+            "verbose": verbose,
+        })
+    
+    async def runtime_fix(
+        self,
+        log_timestamp: Optional[str] = None,
+        dry_run: bool = False,
+        auto_apply: bool = False,
+        auto_fix_loop: bool = False,
+        test_timeout: int = 30,
+        test_port: int = 8000
+    ) -> Dict[str, Any]:
+        """Fix runtime errors"""
+        args = {
+            "dry_run": dry_run,
+            "auto_apply": auto_apply,
+            "auto_fix_loop": auto_fix_loop,
+            "test_timeout": test_timeout,
+            "test_port": test_port,
+        }
+        if log_timestamp:
+            args["log_timestamp"] = log_timestamp
+        return await self.execute_command("runtime", "fix", args)
+
+
+# Instance toàn cục
+cli_wrapper = CLIWrapper()

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,0 +1,99 @@
+"""
+Cấu hình cho API Server
+Tất cả comment đều bằng tiếng Việt
+"""
+
+import json
+from pathlib import Path
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Cấu hình ứng dụng FastAPI"""
+    
+    # Tên ứng dụng
+    app_name: str = "Midicoder WebGUI API"
+    
+    # Phiên bản API
+    api_version: str = "v1"
+    
+    # Cấu hình server
+    host: str = "localhost"
+    port: int = 6868
+    
+    # Cấu hình CORS (cho phép frontend Angular trên cùng máy)
+    cors_origins: list[str] = [
+        "http://localhost:7272",
+        "http://127.0.0.1:7272",
+    ]
+    
+    # Ngôn ngữ mặc định
+    default_language: str = "vi"
+    supported_languages: list[str] = ["vi", "en"]
+    
+    # Timeout cho CLI commands (giây)
+    cli_timeout: int = 1800  # 30 phút
+    
+    # Cấu hình WebSocket
+    ws_ping_interval: float = 30.0
+    ws_ping_timeout: float = 10.0
+    
+    class Config:
+        env_file = ".env"
+        case_sensitive = True
+
+
+# Instance toàn cục
+settings = Settings()
+
+
+def get_global_config_path() -> Path:
+    """
+    Lấy đường dẫn đến file cấu hình global ~/.midicoder/midicoder.json
+    
+    Returns:
+        Path: Đường dẫn đến file config
+    """
+    home_dir = Path.home()
+    return home_dir / ".midicoder" / "midicoder.json"
+
+
+def load_global_config() -> dict:
+    """
+    Load cấu hình global từ ~/.midicoder/midicoder.json
+    
+    Returns:
+        dict: Cấu hình global, hoặc dict rỗng nếu file không tồn tại
+    """
+    config_path = get_global_config_path()
+    
+    if not config_path.exists():
+        return {}
+    
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return {}
+
+
+def get_project_cwd() -> str:
+    """
+    Lấy đường dẫn working directory từ global config
+    
+    Returns:
+        str: Working directory, hoặc đường dẫn hiện tại nếu không có config
+    """
+    config = load_global_config()
+    
+    # Lấy CWD từ config
+    if "project" in config and "cwd" in config["project"]:
+        return config["project"]["cwd"]
+    
+    # Mặc định: thư mục hiện tại
+    return str(Path.cwd())
+
+
+# Load global config khi khởi động
+_global_config = load_global_config()
+_project_cwd = get_project_cwd()

--- a/api/app/i18n.py
+++ b/api/app/i18n.py
@@ -1,0 +1,251 @@
+"""
+Hỗ trợ đa ngôn ngữ (i18n) cho API
+Ngôn ngữ mặc định: Tiếng Việt (vi)
+Ngôn ngữ thứ 2: Tiếng Anh (en)
+"""
+
+from typing import Dict, Any, Optional
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+
+# Từ điển dịch cho Tiếng Việt (mặc định)
+VI_TRANSLATIONS: Dict[str, Dict[str, str]] = {
+    # Common messages
+    "common.success": "Thành công",
+    "common.error": "Lỗi",
+    "common.loading": "Đang xử lý...",
+    "common.processing": "Đang xử lý",
+    "common.completed": "Hoàn thành",
+    "common.failed": "Thất bại",
+    "common.canceled": "Đã hủy",
+    
+    # API responses
+    "api.cli_executing": "Đang thực thi lệnh CLI",
+    "api.cli_completed": "Lệnh CLI đã hoàn thành",
+    "api.cli_failed": "Lệnh CLI thất bại",
+    "api.cli_timeout": "Lệnh CLI hết thời gian chờ",
+    "api.cli_error": "Lỗi khi thực thi lệnh CLI",
+    
+    # Config commands
+    "config.get_success": "Đã lấy cấu hình thành công",
+    "config.set_success": "Đã cập nhật cấu hình thành công",
+    "config.list_success": "Đã lấy danh sách cấu hình thành công",
+    "config.validate_success": "Cấu hình hợp lệ",
+    "config.validate_failed": "Cấu hình không hợp lệ",
+    "config.reset_success": "Đã đặt lại cấu hình về mặc định",
+    
+    # Init commands
+    "init.success": "Đã khởi tạo dự án thành công",
+    "init.already_initialized": "Dự án đã được khởi tạo",
+    
+    # Version commands
+    "version.create_success": "Đã tạo phiên bản thành công",
+    "version.exists": "Phiên bản đã tồn tại",
+    "version.not_found": "Không tìm thấy phiên bản",
+    
+    # Brief commands
+    "brief.analyze_start": "Đang phân tích brief",
+    "brief.analyze_success": "Đã phân tích brief thành công",
+    "brief.analyze_failed": "Phân tích brief thất bại",
+    "brief.rewrite_start": "Đang viết lại brief",
+    "brief.rewrite_success": "Đã viết lại brief thành công",
+    
+    # Contract commands
+    "contract.gen_start": "Đang tạo hợp đồng DSL",
+    "contract.gen_success": "Đã tạo hợp đồng DSL thành công",
+    "contract.gen_failed": "Tạo hợp đồng DSL thất bại",
+    "contract.check_start": "Đang kiểm tra hợp đồng",
+    "contract.check_success": "Hợp đồng hợp lệ",
+    "contract.check_failed": "Hợp đồng không hợp lệ",
+    
+    # IR commands
+    "ir.build_start": "Đang xây dựng MIR",
+    "ir.build_success": "Đã xây dựng MIR thành công",
+    "ir.build_failed": "Xây dựng MIR thất bại",
+    
+    # Code commands
+    "code.build_start": "Đang tạo kế hoạch code",
+    "code.build_success": "Đã tạo kế hoạch code thành công",
+    "code.gen_start": "Đang tạo code",
+    "code.gen_success": "Đã tạo code thành công",
+    "code.apply_start": "Đang áp dụng code",
+    "code.apply_success": "Đã áp dụng code thành công",
+    
+    # Runtime commands
+    "runtime.test_start": "Đang test runtime",
+    "runtime.test_success": "Test runtime thành công",
+    "runtime.test_failed": "Test runtime thất bại",
+    "runtime.fix_start": "Đang sửa lỗi runtime",
+    "runtime.fix_success": "Đã sửa lỗi runtime thành công",
+    
+    # Errors
+    "error.not_found": "Không tìm thấy",
+    "error.invalid_request": "Yêu cầu không hợp lệ",
+    "error.internal_server": "Lỗi server bên trong",
+    "error.unauthorized": "Chưa được xác thực",
+    "error.forbidden": "Không có quyền",
+    "error.timeout": "Hết thời gian chờ",
+    "error.command_failed": "Lệnh thất bại",
+    
+    # Status
+    "status.pending": "Đang chờ",
+    "status.running": "Đang chạy",
+    "status.completed": "Hoàn thành",
+    "status.failed": "Thất bại",
+}
+
+# Từ điển dịch cho Tiếng Anh
+EN_TRANSLATIONS: Dict[str, Dict[str, str]] = {
+    # Common messages
+    "common.success": "Success",
+    "common.error": "Error",
+    "common.loading": "Loading...",
+    "common.processing": "Processing",
+    "common.completed": "Completed",
+    "common.failed": "Failed",
+    "common.canceled": "Canceled",
+    
+    # API responses
+    "api.cli_executing": "Executing CLI command",
+    "api.cli_completed": "CLI command completed",
+    "api.cli_failed": "CLI command failed",
+    "api.cli_timeout": "CLI command timed out",
+    "api.cli_error": "Error executing CLI command",
+    
+    # Config commands
+    "config.get_success": "Configuration retrieved successfully",
+    "config.set_success": "Configuration updated successfully",
+    "config.list_success": "Configuration list retrieved successfully",
+    "config.validate_success": "Configuration is valid",
+    "config.validate_failed": "Configuration is invalid",
+    "config.reset_success": "Configuration reset to defaults",
+    
+    # Init commands
+    "init.success": "Project initialized successfully",
+    "init.already_initialized": "Project already initialized",
+    
+    # Version commands
+    "version.create_success": "Version created successfully",
+    "version.exists": "Version already exists",
+    "version.not_found": "Version not found",
+    
+    # Brief commands
+    "brief.analyze_start": "Analyzing brief",
+    "brief.analyze_success": "Brief analyzed successfully",
+    "brief.analyze_failed": "Brief analysis failed",
+    "brief.rewrite_start": "Rewriting brief",
+    "brief.rewrite_success": "Brief rewritten successfully",
+    
+    # Contract commands
+    "contract.gen_start": "Generating DSL contract",
+    "contract.gen_success": "DSL contract generated successfully",
+    "contract.gen_failed": "DSL contract generation failed",
+    "contract.check_start": "Checking contract",
+    "contract.check_success": "Contract is valid",
+    "contract.check_failed": "Contract is invalid",
+    
+    # IR commands
+    "ir.build_start": "Building MIR",
+    "ir.build_success": "MIR built successfully",
+    "ir.build_failed": "MIR build failed",
+    
+    # Code commands
+    "code.build_start": "Building code plan",
+    "code.build_success": "Code plan built successfully",
+    "code.gen_start": "Generating code",
+    "code.gen_success": "Code generated successfully",
+    "code.apply_start": "Applying code",
+    "code.apply_success": "Code applied successfully",
+    
+    # Runtime commands
+    "runtime.test_start": "Testing runtime",
+    "runtime.test_success": "Runtime test passed",
+    "runtime.test_failed": "Runtime test failed",
+    "runtime.fix_start": "Fixing runtime errors",
+    "runtime.fix_success": "Runtime errors fixed successfully",
+    
+    # Errors
+    "error.not_found": "Not found",
+    "error.invalid_request": "Invalid request",
+    "error.internal_server": "Internal server error",
+    "error.unauthorized": "Unauthorized",
+    "error.forbidden": "Forbidden",
+    "error.timeout": "Timeout",
+    "error.command_failed": "Command failed",
+    
+    # Status
+    "status.pending": "Pending",
+    "status.running": "Running",
+    "status.completed": "Completed",
+    "status.failed": "Failed",
+}
+
+
+class I18n:
+    """
+    Lớp hỗ trợ i18n
+    Lưu trữ và lấy các bản dịch
+    """
+    
+    def __init__(self):
+        self.translations = {
+            "vi": VI_TRANSLATIONS,
+            "en": EN_TRANSLATIONS,
+        }
+        self.default_language = "vi"
+    
+    def get_language_from_request(self, request: Request) -> str:
+        """
+        Lấy ngôn ngữ từ request
+        Ưu tiên: Header X-Lang > Header X-Language > Query param lang > Mặc định (vi)
+        """
+        # Lấy header từ request headers
+        # FastAPI stores headers in lowercase
+        x_lang = request.headers.get("x-lang") or request.headers.get("x-language")
+        
+        # Ưu tiên header
+        if x_lang and x_lang in self.translations:
+            return x_lang
+        
+        # Query param
+        lang = request.query_params.get("lang")
+        if lang and lang in self.translations:
+            return lang
+        
+        # Mặc định
+        return self.default_language
+    
+    def translate(self, key: str, language: str = "vi", **kwargs) -> str:
+        """
+        Dịch một key sang ngôn ngữ chỉ định
+        
+        Args:
+            key: Key của message (ví dụ: "common.success")
+            language: Ngôn ngữ đích (vi, en)
+            **kwargs: Các tham số để format string
+        
+        Returns:
+            Message đã dịch
+        """
+        if language not in self.translations:
+            language = self.default_language
+        
+        message = self.translations[language].get(key, key)
+        
+        # Format string nếu có kwargs
+        if kwargs:
+            try:
+                message = message.format(**kwargs)
+            except (KeyError, ValueError):
+                pass
+        
+        return message
+    
+    def get_all_languages(self) -> list[str]:
+        """Trả về danh sách ngôn ngữ được hỗ trợ"""
+        return list(self.translations.keys())
+
+
+# Instance toàn cục
+i18n = I18n()

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,0 +1,149 @@
+"""
+Main entrypoint cho FastAPI application
+Midicoder WebGUI API Server
+"""
+
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+# Thêm đường dẫn đến midicoder vào sys.path
+# Để đảm bảo có thể import midicoder module
+midicoder_path = Path(__file__).parent.parent.parent.resolve()
+if str(midicoder_path) not in sys.path:
+    sys.path.insert(0, str(midicoder_path))
+
+from app.config import settings
+from app.i18n import i18n
+from app.models import ApiResponse, ErrorResponse
+from app.routers import health, config, index, version, brief, contract, ir, code, runtime
+
+
+# Tạo FastAPI application
+app = FastAPI(
+    title=settings.app_name,
+    version=settings.api_version,
+    description="API Server cho Midicoder WebGUI - CLI Wrapper",
+    openapi_tags=[
+        {"name": "Health", "description": "Health check và thông tin hệ thống"},
+        {"name": "Config", "description": "Quản lý cấu hình"},
+        {"name": "Index", "description": "Quản lý index"},
+        {"name": "Version", "description": "Quản lý phiên bản"},
+        {"name": "Brief", "description": "Xử lý brief"},
+        {"name": "Contract", "description": "Quản lý DSL contracts"},
+        {"name": "IR", "description": "Build và quản lý MIR"},
+        {"name": "Code", "description": "Generate và apply code"},
+        {"name": "Runtime", "description": "Test và fix runtime"},
+    ],
+)
+
+
+# Thiết lập CORS cho frontend Angular trên cùng máy
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+# Middleware để xử lý lỗi toàn cục
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception):
+    """Xử lý lỗi toàn cục với i18n"""
+    language = i18n.get_language_from_request(request)
+    
+    return JSONResponse(
+        status_code=500,
+        content={
+            "success": False,
+            "error": {
+                "code": "INTERNAL_SERVER_ERROR",
+                "message": i18n.translate("error.internal_server", language),
+                "details": str(exc),
+            },
+            "timestamp": "2026-04-10T12:00:00Z",  # Will be set by response model
+            "language": language,
+        },
+    )
+
+
+# Route root
+@app.get("/", response_model=ApiResponse)
+async def root(request: Request):
+    """
+    Root endpoint - Thông tin API
+    
+    Returns:
+        ApiResponse: Thông tin cơ bản về API
+    """
+    language = i18n.get_language_from_request(request)
+    
+    return ApiResponse(
+        success=True,
+        data={
+            "app_name": settings.app_name,
+            "api_version": settings.api_version,
+            "documentation": "/docs",
+        },
+        message=i18n.translate("common.success", language),
+        language=language,
+    )
+
+
+# Override default docs URLs để đặt tại /docs
+app.openapi_url = "/openapi.json"
+app.docs_url = "/docs"
+app.redoc_url = "/redoc"
+
+
+# Thêm các routers
+# Health và system
+app.include_router(health.router, prefix="/api")
+
+# Config
+app.include_router(config.router, prefix="/api")
+
+# Index
+app.include_router(index.router, prefix="/api")
+
+# Version
+app.include_router(version.router, prefix="/api")
+
+# Brief
+app.include_router(brief.router, prefix="/api")
+
+# Contract
+app.include_router(contract.router, prefix="/api")
+
+# IR
+app.include_router(ir.router, prefix="/api")
+
+# Code
+app.include_router(code.router, prefix="/api")
+
+# Runtime
+app.include_router(runtime.router, prefix="/api")
+
+
+# Endpoint để lấy OpenAPI schema với prefix /api
+@app.get("/api/v1/openapi.json", include_in_schema=False)
+async def get_openapi():
+    """Trả về OpenAPI schema"""
+    return app.openapi()
+
+
+if __name__ == "__main__":
+    import uvicorn
+    
+    # Chạy server với port 6868
+    uvicorn.run(
+        "app.main:app",
+        host=settings.host,
+        port=settings.port,
+        reload=False,
+    )

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -1,0 +1,280 @@
+"""
+Các mô hình Pydantic cho API
+Định nghĩa request/response bodies
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+from pydantic import BaseModel, Field
+
+
+class ApiResponse(BaseModel):
+    """
+    Response chung cho tất cả các endpoint
+    """
+    success: bool = Field(..., description="Kết quả thành công hay thất bại")
+    data: Optional[Any] = Field(default=None, description="Dữ liệu trả về")
+    message: Optional[str] = Field(default=None, description="Thông điệp")
+    timestamp: datetime = Field(default_factory=datetime.utcnow, description="Thời gian phản hồi")
+    language: str = Field(default="vi", description="Ngôn ngữ của response")
+
+
+class ErrorResponse(BaseModel):
+    """
+    Response lỗi
+    """
+    success: bool = Field(default=False)
+    error: Dict[str, Any] = Field(..., description="Chi tiết lỗi")
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    language: str = Field(default="vi")
+
+
+class CLICommandRequest(BaseModel):
+    """
+    Request để thực thi một lệnh CLI
+    """
+    command: str = Field(..., description="Tên command (init, brief, contract, ir, code, runtime)")
+    subcommand: Optional[str] = Field(default=None, description="Subcommand")
+    args: Dict[str, Any] = Field(default={}, description="Các đối số cho command")
+
+
+class CLICommandResponse(BaseModel):
+    """
+    Response từ việc thực thi CLI command
+    """
+    command: str
+    subcommand: Optional[str]
+    success: bool
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    duration_ms: int
+    message: str
+
+
+# ==================== Config Models ====================
+
+class ConfigGetRequest(BaseModel):
+    """Request lấy giá trị config"""
+    key: str = Field(..., description="Key của config")
+
+
+class ConfigSetRequest(BaseModel):
+    """Request đặt giá trị config"""
+    key: str = Field(..., description="Key của config")
+    value: str = Field(..., description="Giá trị mới")
+
+
+class ConfigGetResponse(BaseModel):
+    """Response lấy giá trị config"""
+    key: str
+    value: Any
+
+
+class ConfigListResponse(BaseModel):
+    """Response danh sách config"""
+    config: Dict[str, Any]
+
+
+# ==================== Init Models ====================
+
+class InitRequest(BaseModel):
+    """Request khởi tạo dự án"""
+    non_interactive: bool = Field(default=True, description="Chế độ không tương tác")
+    working_dir: Optional[str] = Field(default=None, description="Thư mục làm việc")
+    stack: Optional[str] = Field(default=None, description="Tech stack (e.g., fastapi,nest,angular)")
+    llm_high_provider: Optional[str] = Field(default=None, description="LLM provider tier cao")
+    llm_high_model: Optional[str] = Field(default=None, description="LLM model tier cao")
+    llm_high_url: Optional[str] = Field(default=None, description="LLM URL tier cao")
+    llm_high_key_env: Optional[str] = Field(default=None, description="Env var chứa API key tier cao")
+    llm_cheap_provider: Optional[str] = Field(default=None, description="LLM provider tier rẻ")
+    llm_cheap_model: Optional[str] = Field(default=None, description="LLM model tier rẻ")
+    llm_cheap_url: Optional[str] = Field(default=None, description="LLM URL tier rẻ")
+    llm_cheap_key_env: Optional[str] = Field(default=None, description="Env var chứa API key tier rẻ")
+
+
+class InitResponse(BaseModel):
+    """Response khởi tạo dự án"""
+    initialized: bool
+    working_dir: Optional[str]
+
+
+# ==================== Version Models ====================
+
+class VersionCreateRequest(BaseModel):
+    """Request tạo phiên bản mới"""
+    version: str = Field(..., description="Tên phiên bản (e.g., v1.0.0)")
+
+
+class VersionCreateResponse(BaseModel):
+    """Response tạo phiên bản"""
+    version: str
+    created: bool
+
+
+# ==================== Index Models ====================
+
+class IndexReindexRequest(BaseModel):
+    """Request reindex các file đã thay đổi"""
+    paths: list[str] = Field(default=[], description="Danh sách đường dẫn file đã thay đổi")
+
+
+class IndexResponse(BaseModel):
+    """Response index"""
+    indexed: bool
+    files_count: Optional[int] = None
+
+
+# ==================== Brief Models ====================
+
+class BriefAnalyzeResponse(BaseModel):
+    """Response phân tích brief"""
+    analyzed: bool
+    status: str  # needs_clarification, ready_for_contract
+    ambiguities: list[Dict[str, Any]]
+
+
+class BriefRewriteResponse(BaseModel):
+    """Response viết lại brief"""
+    rewritten: bool
+    content: Optional[str]
+
+
+# ==================== Contract Models ====================
+
+class ContractGenResponse(BaseModel):
+    """Response tạo contract"""
+    generated: bool
+    contract_path: Optional[str]
+    manifest_path: Optional[str]
+
+
+class ContractCheckResponse(BaseModel):
+    """Response kiểm tra contract"""
+    valid: bool
+    errors: list[Dict[str, Any]]
+    warnings: list[Dict[str, Any]]
+
+
+class ContractFeedbackRequest(BaseModel):
+    """Request feedback cho contract"""
+    feedback: str = Field(..., description="Phản hồi về contract")
+
+
+class ContractFeedbackResponse(BaseModel):
+    """Response feedback"""
+    processed: bool
+
+
+# ==================== IR Models ====================
+
+class IRBuildRequest(BaseModel):
+    """Request build IR"""
+    skip_diagrams: bool = Field(default=False, description="Bỏ qua tạo diagrams")
+
+
+class IRBuildResponse(BaseModel):
+    """Response build IR"""
+    built: bool
+    mir_path: Optional[str]
+    symbol_table_path: Optional[str]
+
+
+# ==================== Code Models ====================
+
+class CodeBuildResponse(BaseModel):
+    """Response build code plan"""
+    built: bool
+    plan_path: Optional[str]
+
+
+class CodeGenRequest(BaseModel):
+    """Request generate code"""
+    runtime: bool = Field(default=False, description="Cũng generate runtime files")
+
+
+class CodeGenResponse(BaseModel):
+    """Response generate code"""
+    generated: bool
+    generated_path: Optional[str]
+    report_path: Optional[str]
+
+
+class CodeApplyRequest(BaseModel):
+    """Request apply code"""
+    force: bool = Field(default=False, description="Force apply khi có conflict")
+    dry_run: bool = Field(default=False, description="Xem trước mà không viết file")
+    no_reindex: bool = Field(default=False, description="Tắt reindex (chỉ debug)")
+    patches_subdir: Optional[str] = Field(default=None, description="Thư mục patches tùy chỉnh")
+
+
+class CodeApplyResponse(BaseModel):
+    """Response apply code"""
+    applied: bool
+    files_count: Optional[int]
+    conflicts: list[Dict[str, Any]]
+    status_path: Optional[str]
+
+
+# ==================== Runtime Models ====================
+
+class RuntimeTestRequest(BaseModel):
+    """Request test runtime"""
+    timeout: int = Field(default=30, description="Timeout tính bằng giây")
+    port: int = Field(default=8000, description="Port cho FastAPI")
+    verbose: bool = Field(default=False, description="Hiển thị output chi tiết")
+
+
+class RuntimeTestResponse(BaseModel):
+    """Response test runtime"""
+    passed: bool
+    errors: list[Dict[str, Any]]
+    logs: str
+
+
+class RuntimeFixRequest(BaseModel):
+    """Request fix runtime errors"""
+    log_timestamp: Optional[str] = Field(default=None, description="Timestamp cụ thể để fix")
+    dry_run: bool = Field(default=False, description="Xem trước fixes")
+    auto_apply: bool = Field(default=False, description="Tự động apply fixes")
+    auto_fix_loop: bool = Field(default=False, description="Chạy loop fix cho đến khi pass")
+    test_timeout: int = Field(default=30, description="Timeout cho mỗi lần test")
+    test_port: int = Field(default=8000, description="Port cho test")
+
+
+class RuntimeFixResponse(BaseModel):
+    """Response fix runtime"""
+    fixed: bool
+    patch_plans: list[str]
+    applied: bool
+
+
+# ==================== Health & Status Models ====================
+
+class HealthResponse(BaseModel):
+    """Response health check"""
+    status: str = "healthy"
+    version: str
+    timestamp: datetime
+
+
+class LanguagesResponse(BaseModel):
+    """Response danh sách ngôn ngữ"""
+    languages: list[str]
+    default: str
+
+
+# ==================== Pipeline Status Models ====================
+
+class PipelineStatus(BaseModel):
+    """Trạng thái pipeline hiện tại"""
+    version: Optional[str]
+    brief_analyzed: bool = False
+    brief_clarified: bool = False
+    contract_generated: bool = False
+    contract_validated: bool = False
+    ir_built: bool = False
+    code_planned: bool = False
+    code_generated: bool = False
+    code_applied: bool = False
+    last_updated: Optional[datetime]

--- a/api/app/routers/__init__.py
+++ b/api/app/routers/__init__.py
@@ -1,0 +1,3 @@
+"""
+Routers cho API
+"""

--- a/api/app/routers/brief.py
+++ b/api/app/routers/brief.py
@@ -1,0 +1,77 @@
+"""
+Router cho các commands về brief
+"""
+
+from fastapi import APIRouter, Request
+
+from app.cli_wrapper import cli_wrapper
+from app.i18n import i18n
+from app.models import ApiResponse
+
+router = APIRouter(prefix="/brief", tags=["Brief"])
+
+
+@router.post("/analyze", response_model=ApiResponse)
+async def analyze_brief(request: Request):
+    """
+    Phân tích brief
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả phân tích brief
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để analyze brief
+    result = await cli_wrapper.brief_analyze()
+    
+    if result["success"]:
+        # Parse stdout_data nếu có
+        data = result.get("stdout_data") or {}
+        return ApiResponse(
+            success=True,
+            data=data,
+            message=i18n.translate("brief.analyze_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/rewrite", response_model=ApiResponse)
+async def rewrite_brief(request: Request):
+    """
+    Viết lại brief
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả viết lại brief
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để rewrite brief
+    result = await cli_wrapper.brief_rewrite()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={"rewritten": True},
+            message=i18n.translate("brief.rewrite_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )

--- a/api/app/routers/code.py
+++ b/api/app/routers/code.py
@@ -1,0 +1,165 @@
+"""
+Router cho các commands về code
+"""
+
+from fastapi import APIRouter, Request
+
+from app.cli_wrapper import cli_wrapper
+from app.i18n import i18n
+from app.models import ApiResponse, CodeGenRequest, CodeApplyRequest
+
+router = APIRouter(prefix="/code", tags=["Code"])
+
+
+@router.post("/build", response_model=ApiResponse)
+async def build_code_plan(request: Request):
+    """
+    Build code plan từ IR
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả build code plan
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để build code plan
+    result = await cli_wrapper.code_build()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={
+                "built": True,
+                "plan_path": ".midicoder/versions/<version>/plan/lowering.json",
+            },
+            message=i18n.translate("code.build_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/plan", response_model=ApiResponse)
+async def plan_code(request: Request):
+    """
+    Plan code (alias của build)
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả plan code
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để plan code
+    result = await cli_wrapper.code_plan()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={
+                "planned": True,
+                "plan_path": ".midicoder/versions/<version>/plan/lowering.json",
+            },
+            message=i18n.translate("code.build_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/gen", response_model=ApiResponse)
+async def generate_code(request_data: CodeGenRequest = None, request: Request = None):
+    """
+    Generate code từ plan
+    
+    Args:
+        request_data: Tham số generate code
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả generate code
+    """
+    if request_data is None:
+        request_data = CodeGenRequest()
+    
+    language = i18n.get_language_from_request(request) if request else "vi"
+    
+    # Gọi CLI wrapper để generate code
+    result = await cli_wrapper.code_gen(runtime=request_data.runtime)
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={
+                "generated": True,
+                "generated_path": ".midicoder/versions/<version>/code/generated",
+                "report_path": ".midicoder/versions/<version>/code/report.json",
+            },
+            message=i18n.translate("code.gen_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/apply", response_model=ApiResponse)
+async def apply_code(request_data: CodeApplyRequest = None, request: Request = None):
+    """
+    Apply code vào working directory
+    
+    Args:
+        request_data: Tham số apply code
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả apply code
+    """
+    if request_data is None:
+        request_data = CodeApplyRequest()
+    
+    language = i18n.get_language_from_request(request) if request else "vi"
+    
+    # Gọi CLI wrapper để apply code
+    result = await cli_wrapper.code_apply(
+        force=request_data.force,
+        dry_run=request_data.dry_run,
+        no_reindex=request_data.no_reindex,
+        patches_subdir=request_data.patches_subdir,
+    )
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={
+                "applied": True,
+                "status_path": ".midicoder/versions/<version>/code/applied/status.json",
+            },
+            message=i18n.translate("code.apply_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )

--- a/api/app/routers/config.py
+++ b/api/app/routers/config.py
@@ -1,0 +1,185 @@
+"""
+Router cho các commands về config
+"""
+
+from fastapi import APIRouter, Request
+
+from app.cli_wrapper import cli_wrapper
+from app.i18n import i18n
+from app.models import ApiResponse, ConfigSetRequest
+
+router = APIRouter(prefix="/config", tags=["Config"])
+
+
+@router.get("/list", response_model=ApiResponse)
+async def list_config(request: Request):
+    """
+    Liệt kê tất cả cấu hình
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Danh sách cấu hình
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để lấy config
+    result = await cli_wrapper.config_list()
+    
+    if result["success"]:
+        # Parse stdout để lấy config dict
+        try:
+            config_data = result.get("stdout_data") or {}
+            return ApiResponse(
+                success=True,
+                data=config_data,
+                message=i18n.translate("config.list_success", language),
+                language=language,
+            )
+        except Exception as e:
+            return ApiResponse(
+                success=False,
+                data=None,
+                message=str(e),
+                language=language,
+            )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.get("/get/{key}", response_model=ApiResponse)
+async def get_config(key: str, request: Request):
+    """
+    Lấy giá trị của một key config
+    
+    Args:
+        key: Key của config
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Giá trị config
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để lấy config
+    result = await cli_wrapper.config_get(key)
+    
+    if result["success"]:
+        # Parse stdout để lấy giá trị
+        stdout = result.get("stdout", "").strip()
+        return ApiResponse(
+            success=True,
+            data={"key": key, "value": stdout},
+            message=i18n.translate("config.get_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/set", response_model=ApiResponse)
+async def set_config(config: ConfigSetRequest, request: Request):
+    """
+    Đặt giá trị cho một key config
+    
+    Args:
+        config: Request chứa key và value
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả đặt config
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để set config
+    result = await cli_wrapper.config_set(config.key, config.value)
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={"key": config.key, "value": config.value},
+            message=i18n.translate("config.set_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/validate", response_model=ApiResponse)
+async def validate_config(request: Request):
+    """
+    Validate cấu hình hiện tại
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả validate
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để validate config
+    result = await cli_wrapper.config_validate()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data=None,
+            message=i18n.translate("config.validate_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/reset", response_model=ApiResponse)
+async def reset_config(request: Request):
+    """
+    Reset cấu hình về mặc định
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả reset
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để reset config
+    result = await cli_wrapper.config_reset()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data=None,
+            message=i18n.translate("config.reset_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )

--- a/api/app/routers/contract.py
+++ b/api/app/routers/contract.py
@@ -1,0 +1,139 @@
+"""
+Router cho các commands về contract
+"""
+
+from fastapi import APIRouter, Request
+
+from app.cli_wrapper import cli_wrapper
+from app.i18n import i18n
+from app.models import ApiResponse
+
+router = APIRouter(prefix="/contract", tags=["Contract"])
+
+
+@router.post("/gen", response_model=ApiResponse)
+async def generate_contract(request: Request):
+    """
+    Generate DSL contract từ brief
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả generate contract
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để generate contract
+    result = await cli_wrapper.contract_gen()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={"generated": True},
+            message=i18n.translate("contract.gen_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/gen/resume", response_model=ApiResponse)
+async def resume_contract_gen(request: Request):
+    """
+    Tiếp tục generate contract (resume)
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả resume contract generation
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để resume contract gen
+    result = await cli_wrapper.contract_gen_resume()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={"resumed": True},
+            message=i18n.translate("contract.gen_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/check", response_model=ApiResponse)
+async def check_contract(request: Request):
+    """
+    Kiểm tra contract
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả kiểm tra contract
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để check contract
+    result = await cli_wrapper.contract_check()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={"valid": True},
+            message=i18n.translate("contract.check_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/feedback", response_model=ApiResponse)
+async def contract_feedback(request: Request):
+    """
+    Feedback cho contract
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả feedback
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để contract feedback
+    result = await cli_wrapper.contract_feedback()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={"processed": True},
+            message=i18n.translate("common.success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )

--- a/api/app/routers/health.py
+++ b/api/app/routers/health.py
@@ -1,0 +1,110 @@
+"""
+Router cho health check và thông tin hệ thống
+"""
+
+from datetime import datetime
+from fastapi import APIRouter, Request
+
+from app.config import settings, get_project_cwd, get_global_config_path
+from app.i18n import i18n
+from app.models import ApiResponse, HealthResponse, LanguagesResponse
+
+router = APIRouter(prefix="/health", tags=["Health"])
+
+
+@router.get("/", response_model=HealthResponse)
+async def health_check():
+    """
+    Kiểm tra trạng thái health của API
+    
+    Returns:
+        HealthResponse: Trạng thái health
+    """
+    return HealthResponse(
+        status="healthy",
+        version=settings.api_version,
+        timestamp=datetime.utcnow(),
+    )
+
+
+@router.get("/ready", response_model=HealthResponse)
+async def ready_check():
+    """
+    Kiểm tra API đã sẵn sàng chưa
+    
+    Returns:
+        HealthResponse: Trạng thái ready
+    """
+    return HealthResponse(
+        status="ready",
+        version=settings.api_version,
+        timestamp=datetime.utcnow(),
+    )
+
+
+@router.get("/info", response_model=ApiResponse)
+async def get_info(request: Request):
+    """
+    Lấy thông tin API
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Thông tin API
+    """
+    language = i18n.get_language_from_request(request)
+    
+    return ApiResponse(
+        success=True,
+        data={
+            "app_name": settings.app_name,
+            "api_version": settings.api_version,
+            "host": settings.host,
+            "port": settings.port,
+            "default_language": settings.default_language,
+            "supported_languages": settings.supported_languages,
+        },
+        message=i18n.translate("common.success", language),
+        language=language,
+    )
+
+
+@router.get("/languages", response_model=LanguagesResponse)
+async def get_languages(request: Request):
+    """
+    Lấy danh sách ngôn ngữ được hỗ trợ
+    
+    Returns:
+        LanguagesResponse: Danh sách ngôn ngữ
+    """
+    return LanguagesResponse(
+        languages=i18n.get_all_languages(),
+        default=settings.default_language,
+    )
+
+
+@router.get("/status", response_model=ApiResponse)
+async def get_status(request: Request):
+    """
+    Lấy trạng thái hệ thống và CWD hiện tại
+    
+    Returns:
+        ApiResponse: Thông tin status và CWD
+    """
+    language = i18n.get_language_from_request(request)
+    
+    cwd = get_project_cwd()
+    config_path = get_global_config_path()
+    
+    return ApiResponse(
+        success=True,
+        data={
+            "cwd": cwd,
+            "global_config_path": str(config_path),
+            "global_config_exists": config_path.exists(),
+            "api_ready": True,
+        },
+        message=i18n.translate("common.success", language),
+        language=language,
+    )

--- a/api/app/routers/index.py
+++ b/api/app/routers/index.py
@@ -1,0 +1,79 @@
+"""
+Router cho các commands về index
+"""
+
+from fastapi import APIRouter, Request
+
+from app.cli_wrapper import cli_wrapper
+from app.i18n import i18n
+from app.models import ApiResponse, IndexReindexRequest
+
+router = APIRouter(prefix="/index", tags=["Index"])
+
+
+@router.post("/", response_model=ApiResponse)
+async def build_index(request: Request):
+    """
+    Build index từ codebase
+    
+    Args:
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả build index
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để build index
+    result = await cli_wrapper.index_build()
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={"indexed": True},
+            message=i18n.translate("common.success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )
+
+
+@router.post("/reindex", response_model=ApiResponse)
+async def reindex(request_data: IndexReindexRequest = None, request: Request = None):
+    """
+    Reindex các file đã thay đổi
+    
+    Args:
+        request_data: Danh sách file paths đã thay đổi
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả reindex
+    """
+    if request_data is None:
+        request_data = IndexReindexRequest()
+    
+    language = i18n.get_language_from_request(request) if request else "vi"
+    
+    # Gọi CLI wrapper để reindex
+    result = await cli_wrapper.index_reindex(request_data.paths if request_data.paths else None)
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={"indexed": True, "files_count": len(request_data.paths) if request_data.paths else 0},
+            message=i18n.translate("common.success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )

--- a/api/app/routers/ir.py
+++ b/api/app/routers/ir.py
@@ -1,0 +1,51 @@
+"""
+Router cho các commands về IR (MIR)
+"""
+
+from fastapi import APIRouter, Request
+
+from app.cli_wrapper import cli_wrapper
+from app.i18n import i18n
+from app.models import ApiResponse, IRBuildRequest
+
+router = APIRouter(prefix="/ir", tags=["IR"])
+
+
+@router.post("/build", response_model=ApiResponse)
+async def build_ir(request_data: IRBuildRequest = None, request: Request = None):
+    """
+    Build IR (MIR) từ contracts
+    
+    Args:
+        request_data: Tham số build IR
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả build IR
+    """
+    if request_data is None:
+        request_data = IRBuildRequest()
+    
+    language = i18n.get_language_from_request(request) if request else "vi"
+    
+    # Gọi CLI wrapper để build IR
+    result = await cli_wrapper.ir_build(skip_diagrams=request_data.skip_diagrams)
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={
+                "built": True,
+                "mir_path": ".midicoder/versions/<version>/ir/mir.json",
+                "symbol_table_path": ".midicoder/versions/<version>/ir/symbol-table.json",
+            },
+            message=i18n.translate("ir.build_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )

--- a/api/app/routers/runtime.py
+++ b/api/app/routers/runtime.py
@@ -1,0 +1,103 @@
+"""
+Router cho các commands về runtime
+"""
+
+from fastapi import APIRouter, Request
+
+from app.cli_wrapper import cli_wrapper
+from app.i18n import i18n
+from app.models import ApiResponse, RuntimeTestRequest, RuntimeFixRequest
+
+router = APIRouter(prefix="/runtime", tags=["Runtime"])
+
+
+@router.post("/test", response_model=ApiResponse)
+async def test_runtime(request_data: RuntimeTestRequest = None, request: Request = None):
+    """
+    Test runtime của generated code
+    
+    Args:
+        request_data: Tham số test runtime
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả test runtime
+    """
+    if request_data is None:
+        request_data = RuntimeTestRequest()
+    
+    language = i18n.get_language_from_request(request) if request else "vi"
+    
+    # Gọi CLI wrapper để test runtime
+    result = await cli_wrapper.runtime_test(
+        timeout=request_data.timeout,
+        port=request_data.port,
+        verbose=request_data.verbose,
+    )
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={
+                "passed": True,
+                "logs": result.get("stdout", ""),
+            },
+            message=i18n.translate("runtime.test_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data={
+            "passed": False,
+            "logs": result.get("stderr", ""),
+        },
+        message=result.get("stderr", i18n.translate("runtime.test_failed", language)),
+        language=language,
+    )
+
+
+@router.post("/fix", response_model=ApiResponse)
+async def fix_runtime(request_data: RuntimeFixRequest = None, request: Request = None):
+    """
+    Fix runtime errors sử dụng LLM
+    
+    Args:
+        request_data: Tham số fix runtime
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả fix runtime
+    """
+    if request_data is None:
+        request_data = RuntimeFixRequest()
+    
+    language = i18n.get_language_from_request(request) if request else "vi"
+    
+    # Gọi CLI wrapper để fix runtime
+    result = await cli_wrapper.runtime_fix(
+        log_timestamp=request_data.log_timestamp,
+        dry_run=request_data.dry_run,
+        auto_apply=request_data.auto_apply,
+        auto_fix_loop=request_data.auto_fix_loop,
+        test_timeout=request_data.test_timeout,
+        test_port=request_data.test_port,
+    )
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={
+                "fixed": True,
+                "applied": request_data.auto_apply,
+            },
+            message=i18n.translate("runtime.fix_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )

--- a/api/app/routers/version.py
+++ b/api/app/routers/version.py
@@ -1,0 +1,47 @@
+"""
+Router cho các commands về version
+"""
+
+from fastapi import APIRouter, Request
+
+from app.cli_wrapper import cli_wrapper
+from app.i18n import i18n
+from app.models import ApiResponse, VersionCreateRequest
+
+router = APIRouter(prefix="/version", tags=["Version"])
+
+
+@router.post("/create", response_model=ApiResponse)
+async def create_version(request_data: VersionCreateRequest, request: Request):
+    """
+    Tạo phiên bản mới
+    
+    Args:
+        request_data: Tên phiên bản cần tạo
+        request: Request object để lấy ngôn ngữ
+    
+    Returns:
+        ApiResponse: Kết quả tạo phiên bản
+    """
+    language = i18n.get_language_from_request(request)
+    
+    # Gọi CLI wrapper để create version
+    result = await cli_wrapper.version_create(request_data.version)
+    
+    if result["success"]:
+        return ApiResponse(
+            success=True,
+            data={
+                "version": request_data.version,
+                "created": True,
+            },
+            message=i18n.translate("version.create_success", language),
+            language=language,
+        )
+    
+    return ApiResponse(
+        success=False,
+        data=None,
+        message=result.get("stderr", "Unknown error"),
+        language=language,
+    )

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,14 @@
+# Dependencies cho Midicoder WebGUI API
+# FastAPI và runtime
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+
+# Pydantic và settings
+pydantic>=2.9.0
+pydantic-settings>=2.6.0
+
+# HTTP client (nếu cần)
+httpx>=0.27.0
+
+# WebSocket (optional, nếu cần thêm)
+websockets>=13.0

--- a/api/start_api.bat
+++ b/api/start_api.bat
@@ -1,0 +1,37 @@
+@echo off
+REM Script để khởi động Midicoder WebGUI API Server
+REM Chạy file này để start API trên port 6868
+REM
+REM LƯU Ý: Trước khi chạy API, phải init dự án bằng CLI:
+REM   midicoder init
+REM Command này sẽ tạo ~/.midicoder/midicoder.json với CWD
+REM API sẽ tự động load CWD từ file config này
+
+echo ========================================
+echo Midicoder WebGUI API Server
+echo ========================================
+echo Port: 6868
+echo Swagger UI: http://localhost:6868/docs
+echo Status API: http://localhost:6868/api/health/status
+echo ========================================
+echo.
+echo LƯU Ý:
+echo - Đảm bảo đã chạy: midicoder init
+echo - CWD được load từ ~/.midicoder/midicoder.json
+echo - Đổi CWD bằng: midicoder config set cwd "new-dir"
+echo ========================================
+echo.
+
+cd /d "%~dp0"
+
+REM Set PYTHONPATH để Python tìm thấy module 'app'
+set PYTHONPATH=%~dp0;%PYTHONPATH%
+
+echo Starting API server...
+echo.
+
+REM Chạy uvicorn
+python -m uvicorn app.main:app --host 0.0.0.0 --port 6868
+
+REM Nếu script thoát, chờ user nhấn phím
+pause


### PR DESCRIPTION
# Thêm API Server cho Midicoder WebGUI

## Tổng quan
Implement FastAPI backend để đóng vai trò CLI wrapper, cung cấp HTTP endpoints cho WebGUI (Angular) tương tác với Midicoder CLI.

## Thay đổi chính
- ✅ Thêm thư mục `api/` với cấu trúc FastAPI
- ✅ 27 endpoints cho các commands: health, config, index, version, brief, contract, ir, code, runtime
- ✅ i18n support: Tiếng Việt (mặc định) + Tiếng Anh (header `X-Lang: en`)
- ✅ API load CWD từ `~/.midicoder/midicoder.json` (không có endpoint `init`)
- ✅ CLI wrapper thuần túy, không thêm logic business
- ✅ Server chạy trên port `6868`
- ✅ Swagger UI tại http://localhost:6868/docs
- ✅ Tất cả comment bằng tiếng Việt

## Cấu trúc
```
api/
├── app/
│   ├── main.py          # FastAPI entrypoint
│   ├── config.py        # Cấu hình + load CWD từ global config
│   ├── i18n.py          # Đa ngôn ngữ
│   ├── models.py        # Pydantic models
│   ├── cli_wrapper.py   # CLI wrapper
│   └── routers/         # Các routers (health, config, version, brief, contract, ir, code, runtime)
├── requirements.txt
└── start_api.bat        # Script start server
```

## Hướng dẫn sử dụng
```bash
# 1. Init dự án (bắt buộc)
midicoder init

# 2. Chạy API
cd api && start_api.bat

# 3. Truy cập Swagger
http://localhost:6868/docs
```

## Kiểm thử
- ✅ Health endpoints: /api/health/, /api/health/status
- ✅ i18n: Tiếng Việt mặc định, Tiếng Anh qua header
- ✅ CLI wrapper gọi commands thành công
- ✅ CWD load đúng từ global config

## Lưu ý
- API và WebGUI thiết kế chỉ làm việc trên một CWD duy nhất
- Đổi CWD bằng: `midicoder config set cwd "new-dir"` rồi restart API